### PR TITLE
[CW66] Feat/api refactor

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -127,29 +127,29 @@ func serveAPI(e *echo.Echo) {
 	// e.POST("/login/", login(userCollection))
 
 	// Routes for posts
-	e.GET("/posts/", getPosts(postsCollection))
-	e.POST("/post/", newPosts(postsCollection))
-	e.PUT("/post/", updatePosts(postsCollection))
-	e.DELETE("/post/", deletePosts(postsCollection))
+	e.GET("/api/posts/", getPosts(postsCollection))
+	e.POST("/api/post/", newPosts(postsCollection))
+	e.PUT("/api/post/", updatePosts(postsCollection))
+	e.DELETE("/api/post/", deletePosts(postsCollection))
 
 	// Routes for categories
-	e.GET("/category/:id/", getCats(catCollection))
-	e.POST("/category/", newCats(catCollection))
-	e.PATCH("/category/", patchCats(catCollection))
-	e.DELETE("/category/", deleteCats(catCollection))
+	e.GET("/api/category/:id/", getCats(catCollection))
+	e.POST("/api/category/", newCats(catCollection))
+	e.PATCH("/api/category/", patchCats(catCollection))
+	e.DELETE("/api/category/", deleteCats(catCollection))
 
 	// Routes for sponsors
-	e.GET("/sponsor/", GetSponsor())
-	e.POST("/sponsor/", NewSponsor())
-	e.DELETE("/sponsor/", DeleteSponsor())
-	e.GET("/sponsors/", GetSponsors())
+	e.GET("/api/sponsor/", GetSponsor())
+	e.POST("/api/sponsor/", NewSponsor())
+	e.DELETE("/api/sponsor/", DeleteSponsor())
+	e.GET("/api/sponsors/", GetSponsors())
 
 	// Routes for enquiries
-	e.POST("/enquiry/sponsorship", HandleEnquiry("sponsorship@csesoc.org.au"))
-	e.POST("/enquiry/info", HandleEnquiry("info@csesoc.org.au"))
+	e.POST("/api/enquiry/sponsorship", HandleEnquiry("sponsorship@csesoc.org.au"))
+	e.POST("/api/enquiry/info", HandleEnquiry("info@csesoc.org.au"))
   
   // Routes for faq
-	e.GET("/faq/", GetFaq())
+	e.GET("/api/faq/", GetFaq())
 }
 
 // func login(collection *mongo.Collection) echo.HandlerFunc {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -105,7 +105,7 @@ export default {
   },
   mounted() {
     fetch(
-      '/sponsors/?token=null'
+      '/api/sponsors/?token=null'
     )
       .then(r => r.json())
       .then((responseJson) => {

--- a/tests/postman/CSESoc Website.postman_collection.json
+++ b/tests/postman/CSESoc Website.postman_collection.json
@@ -48,13 +48,14 @@
 							]
 						},
 						"url": {
-							"raw": "http://localhost:1323/enquiry/sponsorship",
+							"raw": "http://localhost:1323/api/enquiry/sponsorship",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"enquiry",
 								"sponsorship"
 							]
@@ -102,13 +103,14 @@
 							]
 						},
 						"url": {
-							"raw": "http://localhost:1323/enquiry/sponsorship",
+							"raw": "http://localhost:1323/api/enquiry/sponsorship",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"enquiry",
 								"sponsorship"
 							]
@@ -156,13 +158,14 @@
 							]
 						},
 						"url": {
-							"raw": "http://localhost:1323/enquiry/sponsorship",
+							"raw": "http://localhost:1323/api/enquiry/sponsorship",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"enquiry",
 								"sponsorship"
 							]
@@ -210,13 +213,14 @@
 							]
 						},
 						"url": {
-							"raw": "http://localhost:1323/enquiry/sponsorship",
+							"raw": "http://localhost:1323/api/enquiry/sponsorship",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"enquiry",
 								"sponsorship"
 							]
@@ -260,13 +264,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsors/?token=&tier=100",
+							"raw": "http://localhost:1323/api/sponsors/?token=&tier=100",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsors",
 								""
 							],
@@ -316,13 +321,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsors/?token=",
+							"raw": "http://localhost:1323/api/sponsors/?token=",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsors",
 								""
 							],
@@ -357,13 +363,14 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?token=&expire=2020-11-01T22:08:41+00:00&name={{sponsor_name}}&logo=https://static.canva.com/static/images/canva_logo_100x100@2x.png&tier=100",
+							"raw": "http://localhost:1323/api/sponsor/?token=&expire=2020-11-01T22:08:41+00:00&name={{sponsor_name}}&logo=https://static.canva.com/static/images/canva_logo_100x100@2x.png&tier=100",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -415,13 +422,14 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?token=&expire=2020-11-01T22:08:41+00:00&name={{sponsor_name}}&logo=https://static.canva.com/static/images/canva_logo_100x100@2x.png&tier=1000",
+							"raw": "http://localhost:1323/api/sponsor/?token=&expire=2020-11-01T22:08:41+00:00&name={{sponsor_name}}&logo=https://static.canva.com/static/images/canva_logo_100x100@2x.png&tier=1000",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -471,13 +479,14 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?token=&name=Example Company 1&logo=&tier=&expiry",
+							"raw": "http://localhost:1323/api/sponsor/?token=&name=Example Company 1&logo=&tier=&expiry",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -531,13 +540,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsors/?token=null",
+							"raw": "http://localhost:1323/api/sponsors/?token=null",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsors",
 								""
 							],
@@ -572,13 +582,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?name={{sponsor_name}}&token=null",
+							"raw": "http://localhost:1323/api/sponsor/?name={{sponsor_name}}&token=null",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -618,13 +629,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?token=null&name=Non existent",
+							"raw": "http://localhost:1323/api/sponsor/?token=null&name=Non existent",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -664,13 +676,14 @@
 						"method": "DELETE",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?token=null&name={{sponsor_name}}",
+							"raw": "http://localhost:1323/api/sponsor/?token=null&name={{sponsor_name}}",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -715,13 +728,14 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:1323/sponsor/?name={{sponsor_name}}&token=null",
+							"raw": "http://localhost:1323/api/sponsor/?name={{sponsor_name}}&token=null",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
 							"port": "1323",
 							"path": [
+								"api",
 								"sponsor",
 								""
 							],
@@ -743,7 +757,7 @@
 				}
 			],
 			"protocolProfileBehavior": {}
-		}
+		}, 
 		{
 			"name": "Faq",
 			"item": [


### PR DESCRIPTION
## Changes
- Refactor API endpoints to be prefaced with /api/
- Update footer to use new /api/sponsors endpoint
- Update Postman tests to use new endpoints
## Change reason
- Differentiate API requests from routes for pages.
