### PR TITLE
CW-122 Fix target emails for development

### DIFF
--- a/backend/server/mailing.go
+++ b/backend/server/mailing.go
@@ -37,8 +37,10 @@ type Feedback struct {
 // Message bundles
 var feedbackBundle []Feedback
 var infoBundle []Enquiry
-var infoEmail string = "info@csesoc.org.au"
 var sponsorshipBundle []Enquiry
+
+// Email addresses
+var infoEmail string = "info@csesoc.org.au"
 var sponsorshipEmail string = "sponsorship@csesoc.org.au"
 
 // Mailjet session variables
@@ -48,6 +50,11 @@ var mailjetClient *mailjet.Client
 
 // InitMailClient initialises a session with the Mailjet API and stores it in a global variable
 func InitMailClient() {
+	if InDevelopment {
+		infoEmail = "projects.website+info@csesoc.org.au"
+		sponsorshipEmail = "projects.website+sponsorship@csesoc.org.au"
+	}
+
 	mailjetClient = mailjet.NewMailjetClient(publicKey, secretKey)
 
 	// Start mailing timers

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -17,6 +17,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// InDevelopment - flag
+var InDevelopment bool = true
+
 type (
 	// H - interface for sending JSON
 	H map[string]interface{}


### PR DESCRIPTION
## Changes
- Change the target emails for the development phase.

## Change reason
To prevent the official CSESoc email addresses, directors and execs from getting spammed with test emails during the development phase.

## Comments
My name is in those test emails 😱
