### PR TITLE
Feat/about page

### DIFF
--- a/backend/server/constants.go
+++ b/backend/server/constants.go
@@ -6,6 +6,6 @@ const SPONSOR_URL = "api/v1/sponsors"
 const MAILING_URL = "api/v1/mailing"
 const SOCIAL_URL = "api/v1/social"
 const FAQ_URL = "api/v1/faq"
-const AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxNTkzMTI5NjAwLCJ6SUQiOiJ6NTEyMzQ1NiJ9.jYC2qlpzAKIMPFywQ6pWIV1qat_h7OrorJ-zQM5jDpg"
+const AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxNTk4Mzg5MDg2LCJ6SUQiOiJ6NTEyMzQ1NiJ9.a8869YcfgBZCQcWUFuomF4Fqx9nJzT-rWpP2yRVsBWg"
 
 var JWT_SECRET = []byte("temp_secret_until_proper_secrets_are_implemented")

--- a/backend/static/faq.json
+++ b/backend/static/faq.json
@@ -6,5 +6,13 @@
     {
         "question": "How can we help CSE students?",
         "answer": "We are a society for the students, by the students. As a CSE student, we can help you through the weekly events we run and organise; these include: trivia, movie, poker, and boardgame nights, LAN Parties, workshops, code jams, tech talks, and our famous FREE weekly BBQ. Additionally, we run a highly successful First Year Camp, offering new CSE students (both undergraduate and postgraduate) a weekend of Trivia, Dance Parties, Scavenger Hunts and general frivolity with the chance to meet and mingle with other newcomers. The society is entirely run by CSE student volunteers. Since all CSE Students are automatically members, there are plenty of opportunities to get involved with running events and activities. We also cater to new and returning students alike, with a mix of events designed to have something for everyone. Events are open to all members and nearly all are free to attend. Finally, we're as passionate about computing as you are; we provide technical events to teach you new skills, as well as a fortnightly magazine to keep you updated on what's new and interesting within the university, school and industry. Most of all, we're here to help you settle in and have a great time at UNSW!"
+    },
+    {
+        "question": "How can you get involved?",
+        "answer": "The CSESoc Executive and Directors hope you have enjoyed our events and activities - so much so that you wish you had the chance to help run something yourself! If you are interested in helping out in a specific area or are thinking about running for a director/executive position in the future, then joining a subcommittee is the best way to get involved, meet other people and try something new."
+    },
+    {
+        "question": "How can you join a subcommittee?",
+        "answer": "Watch out for our recruitment drives on Facebook, which usually happen at the start of the year. If you'd like more information or have any questions, don't hesitate to send us an enquiry below."
     }
 ]

--- a/frontend/src/assets/execs_directs.json
+++ b/frontend/src/assets/execs_directs.json
@@ -1,0 +1,61 @@
+{
+   "2020": {
+      "Executives": {
+         "Co-Presidents": [
+            "Shane Kadish",
+            "Tammy Zhong"
+         ],
+         "Secretary": [
+            "Sam Push"
+         ],
+         "Treasurer": [
+            "Teresa Feng"
+         ],
+         "Arc Delegate": [
+            "Jeremy Chiu"
+         ],
+         "Grievance Officer": [
+            "Tom Kunc"
+         ]
+      },
+      "Directors": {
+         "Careers": [
+            "Evangeline Endacott",
+            "Low Khye Ean",
+            "Nicholas Duller",
+            "Yan Zhai"
+         ],
+         "CompClub": [
+            "Livia Wijayanti",
+            "Timothy Ryan"
+         ],
+         "Creative": [
+            "Elizabeth Zhong",
+            "Jia Min Guo"
+         ],
+         "Marketing": [
+            "Isaac Joshi",
+            "Jessica Feng"
+         ],
+         "Media": [
+            "Aditi Chandra",
+            "Clarence Shijun Feng"
+         ],
+         "Socials": [
+            "Frances Lee",
+            "Van-Roy Trinh"
+         ],
+         "Software Projects": [
+            "Gordon Zhong",
+            "Leesa Kristina Dang"
+         ],
+         "Student Network": [
+            "Sachin Krishnamoorthy",
+            "Shrey Somaiya"
+         ],
+         "Workshops": [
+            "Michael Gribben"
+         ]
+      }
+   }
+}

--- a/frontend/src/assets/execs_directs.json
+++ b/frontend/src/assets/execs_directs.json
@@ -1,626 +1,668 @@
-{
-   "2020": {
-      "Executives": {
-         "Co-Presidents": [
-            "Shane Kadish",
-            "Tammy Zhong"
-         ],
-         "Secretary": [
-            "Sam Push"
-         ],
-         "Treasurer": [
-            "Teresa Feng"
-         ],
-         "Arc Delegate": [
-            "Jeremy Chiu"
-         ],
-         "Grievance Officer": [
-            "Tom Kunc"
-         ]
-      },
-      "Directors": {
-         "Careers": [
-            "Evangeline Endacott",
-            "Low Khye Ean",
-            "Nicholas Duller",
-            "Yan Zhai"
-         ],
-         "CompClub": [
-            "Livia Wijayanti",
-            "Timothy Ryan"
-         ],
-         "Creative": [
-            "Elizabeth Zhong",
-            "Jia Min Guo"
-         ],
-         "Marketing": [
-            "Isaac Joshi",
-            "Jessica Feng"
-         ],
-         "Media": [
-            "Aditi Chandra",
-            "Clarence Shijun Feng"
-         ],
-         "Socials": [
-            "Frances Lee",
-            "Van-Roy Trinh"
-         ],
-         "Software Projects": [
-            "Gordon Zhong",
-            "Leesa Kristina Dang"
-         ],
-         "Student Network": [
-            "Sachin Krishnamoorthy",
-            "Shrey Somaiya"
-         ],
-         "Workshops": [
-            "Michael Gribben"
-         ]
+[
+   {
+      "year": "2020",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Shane Kadish",
+               "Tammy Zhong"
+            ],
+            "Secretary": [
+               "Sam Push"
+            ],
+            "Treasurer": [
+               "Teresa Feng"
+            ],
+            "Arc Delegate": [
+               "Jeremy Chiu"
+            ],
+            "Grievance Officer": [
+               "Tom Kunc"
+            ]
+         },
+         "Directors": {
+            "Careers": [
+               "Evangeline Endacott",
+               "Low Khye Ean",
+               "Nicholas Duller",
+               "Yan Zhai"
+            ],
+            "CompClub": [
+               "Livia Wijayanti",
+               "Timothy Ryan"
+            ],
+            "Creative": [
+               "Elizabeth Zhong",
+               "Jia Min Guo"
+            ],
+            "Marketing": [
+               "Isaac Joshi",
+               "Jessica Feng"
+            ],
+            "Media": [
+               "Aditi Chandra",
+               "Clarence Shijun Feng"
+            ],
+            "Socials": [
+               "Frances Lee",
+               "Van-Roy Trinh"
+            ],
+            "Software Projects": [
+               "Gordon Zhong",
+               "Leesa Kristina Dang"
+            ],
+            "Student Network": [
+               "Sachin Krishnamoorthy",
+               "Shrey Somaiya"
+            ],
+            "Workshops": [
+               "Michael Gribben"
+            ]
+         }
       }
    },
-   "2019": {
-      "Executives": {
-         "Co-Presidents": [
-            "Alli Murray",
-            "Siddhant Virmani"
-         ],
-         "Secretary": [
-            "Celine Tye"
-         ],
-         "Treasurer": [
-            "Gary Bai (replacing Rachel Liang)"
-         ],
-         "Arc Delegate": [
-            "Peter Nguyen"
-         ]
-      },
-      "Directors": {
-         "Careers": [
-            "Sam Push",
-            "Sophia Lin"
-         ],
-         "CompClub": [
-            "Jeremy Chiu",
-            "Teresa Feng"
-         ],
-         "Marketing": [
-            "Amy Luo",
-            "Taiyue Tan"
-         ],
-         "Media": [
-            "Adrian Martinez",
-            "Mehri Amin"
-         ],
-         "Professional Development & Networking": [
-            "Apurva Shukla"
-         ],
-         "Social Events": [
-            "Selina Chua",
-            "Nathan Ellis"
-         ],
-         "Software Projects": [
-            "Shane Kadish",
-            "Tom Kunc"
-         ],
-         "Student Network": [
-            "Tammy Zhong"
-         ],
-         "Workshops & Academics": [
-            "Oliver Dolk"
-         ]
+   {
+      "year": "2019",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Alli Murray",
+               "Siddhant Virmani"
+            ],
+            "Secretary": [
+               "Celine Tye"
+            ],
+            "Treasurer": [
+               "Gary Bai (replacing Rachel Liang)"
+            ],
+            "Arc Delegate": [
+               "Peter Nguyen"
+            ]
+         },
+         "Directors": {
+            "Careers": [
+               "Sam Push",
+               "Sophia Lin"
+            ],
+            "CompClub": [
+               "Jeremy Chiu",
+               "Teresa Feng"
+            ],
+            "Marketing": [
+               "Amy Luo",
+               "Taiyue Tan"
+            ],
+            "Media": [
+               "Adrian Martinez",
+               "Mehri Amin"
+            ],
+            "Professional Development & Networking": [
+               "Apurva Shukla"
+            ],
+            "Social Events": [
+               "Selina Chua",
+               "Nathan Ellis"
+            ],
+            "Software Projects": [
+               "Shane Kadish",
+               "Tom Kunc"
+            ],
+            "Student Network": [
+               "Tammy Zhong"
+            ],
+            "Workshops & Academics": [
+               "Oliver Dolk"
+            ]
+         }
       }
    },
-   "2018": {
-      "Executives": {
-         "Co-Presidents": [
-            "Ofir Zeevi",
-            "Andrew Vo"
-         ],
-         "Secretary": [
-            "Andrew Kaploun"
-         ],
-         "Treasurer": [
-            "Martin Minh Le"
-         ],
-         "Arc Delegate": [
-            "Raiyan Zubair"
-         ]
-      },
-      "Directors": {
-         "CompClub": [
-            "Peter Arnott",
-            "Lillian Guo"
-         ],
-         "Marketing": [
-            "Celine Tye",
-            "Sheng An Zhang"
-         ],
-         "Professional Development": [
-            "James Treloar"
-         ],
-         "Publications": [
-            "Siddhant Virmani"
-         ],
-         "Social Events": [
-            "Mark Sonnenschein",
-            "Sampath Somanchi"
-         ],
-         "Software Projects": [
-            "Amri Chamela"
-         ],
-         "Sponsored Events": [
-            "Gary Bai",
-            "Conway Ying"
-         ],
-         "Student Network": [
-            "Alli Murray"
-         ],
-         "Workshops & Academics": [
-            "Nicholas Malecki"
-         ]
+   {
+      "year": "2018",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Ofir Zeevi",
+               "Andrew Vo"
+            ],
+            "Secretary": [
+               "Andrew Kaploun"
+            ],
+            "Treasurer": [
+               "Martin Minh Le"
+            ],
+            "Arc Delegate": [
+               "Raiyan Zubair"
+            ]
+         },
+         "Directors": {
+            "CompClub": [
+               "Peter Arnott",
+               "Lillian Guo"
+            ],
+            "Marketing": [
+               "Celine Tye",
+               "Sheng An Zhang"
+            ],
+            "Professional Development": [
+               "James Treloar"
+            ],
+            "Publications": [
+               "Siddhant Virmani"
+            ],
+            "Social Events": [
+               "Mark Sonnenschein",
+               "Sampath Somanchi"
+            ],
+            "Software Projects": [
+               "Amri Chamela"
+            ],
+            "Sponsored Events": [
+               "Gary Bai",
+               "Conway Ying"
+            ],
+            "Student Network": [
+               "Alli Murray"
+            ],
+            "Workshops & Academics": [
+               "Nicholas Malecki"
+            ]
+         }
       }
    },
-   "2017": {
-      "Executives": {
-         "Co-Presidents": [
-            "Nicola Gibson",
-            "Adam Tizzone"
-         ],
-         "Secretary": [
-            "Martin Le"
-         ],
-         "Treasurer": [
-            "Jesse Zhang"
-         ],
-         "Arc Delegate": [
-            "Weilon Ying"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Melissa Zhang"
-         ],
-         "CompClub": [
-            "Nethan Tran",
-            "Angelo Yan"
-         ],
-         "Dev": [
-            "Daniel Cameron"
-         ],
-         "DevSpace": [
-            "Inura De Zoysa"
-         ],
-         "Publicity": [
-            "Vivian Dang"
-         ],
-         "Social": [
-            "Andrew Vo",
-            "Ofir Zeevi"
-         ],
-         "Student Network": [
-            "David Sison"
-         ],
-         "Talks": [
-            "Raiyan Zubair"
-         ],
-         "Workshops": [
-            "Mitch Ball"
-         ]
+   {
+      "year": "2017",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Nicola Gibson",
+               "Adam Tizzone"
+            ],
+            "Secretary": [
+               "Martin Le"
+            ],
+            "Treasurer": [
+               "Jesse Zhang"
+            ],
+            "Arc Delegate": [
+               "Weilon Ying"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Melissa Zhang"
+            ],
+            "CompClub": [
+               "Nethan Tran",
+               "Angelo Yan"
+            ],
+            "Dev": [
+               "Daniel Cameron"
+            ],
+            "DevSpace": [
+               "Inura De Zoysa"
+            ],
+            "Publicity": [
+               "Vivian Dang"
+            ],
+            "Social": [
+               "Andrew Vo",
+               "Ofir Zeevi"
+            ],
+            "Student Network": [
+               "David Sison"
+            ],
+            "Talks": [
+               "Raiyan Zubair"
+            ],
+            "Workshops": [
+               "Mitch Ball"
+            ]
+         }
       }
    },
-   "2016": {
-      "Executives": {
-         "Co-Presidents": [
-            "Lavender Chan",
-            "Jake Bloom"
-         ],
-         "Secretary": [
-            "Carmen Wang"
-         ],
-         "Treasurer": [
-            "Steven Strijakov"
-         ],
-         "Arc Delegate": [
-            "David Sison"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Jayden Tilbrook",
-            "Emily Olorin"
-         ],
-         "CompClub": [
-            "Joseph Hilsberg"
-         ],
-         "Dev": [
-            "Nicholas Whyte"
-         ],
-         "DevSpace": [
-            "John Wiseheart"
-         ],
-         "Publicity": [
-            "Nicola Gibson"
-         ],
-         "Social": [
-            "George Mountakis",
-            "Jathurson Subachandran"
-         ],
-         "Student Network": [
-            "Jesse Zhang"
-         ],
-         "Talks and Workshops": [
-            "Adam Tizzone",
-            "Daniel Phillips"
-         ]
+   {
+      "year": "2016",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Lavender Chan",
+               "Jake Bloom"
+            ],
+            "Secretary": [
+               "Carmen Wang"
+            ],
+            "Treasurer": [
+               "Steven Strijakov"
+            ],
+            "Arc Delegate": [
+               "David Sison"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Jayden Tilbrook",
+               "Emily Olorin"
+            ],
+            "CompClub": [
+               "Joseph Hilsberg"
+            ],
+            "Dev": [
+               "Nicholas Whyte"
+            ],
+            "DevSpace": [
+               "John Wiseheart"
+            ],
+            "Publicity": [
+               "Nicola Gibson"
+            ],
+            "Social": [
+               "George Mountakis",
+               "Jathurson Subachandran"
+            ],
+            "Student Network": [
+               "Jesse Zhang"
+            ],
+            "Talks and Workshops": [
+               "Adam Tizzone",
+               "Daniel Phillips"
+            ]
+         }
       }
    },
-   "2015": {
-      "Executives": {
-         "Co-Presidents": [
-            "Oliver Tan",
-            "Davina Adisusila"
-         ],
-         "Secretary": [
-            "Octavia Soegyono"
-         ],
-         "Treasurer": [
-            "Lucas Pickup"
-         ],
-         "Arc Delegate": [
-            "Karl Krauth"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Jashank Jeremy"
-         ],
-         "CompClub": [
-            "Jason Lim"
-         ],
-         "Dev": [
-            "George Caley"
-         ],
-         "DevSpace": [
-            "Matthew McEwen",
-            "Joshua Elliott"
-         ],
-         "Publicity": [
-            "Lavender Chan"
-         ],
-         "Social": [
-            "Steven Strijakov",
-            "Jake Bloom"
-         ],
-         "Student Network": [
-            "Christopher Manouvrier"
-         ],
-         "Talks and Workshops": [
-            "John Wiseheart",
-            "David Sison"
-         ]
+   {
+      "year": "2015",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Oliver Tan",
+               "Davina Adisusila"
+            ],
+            "Secretary": [
+               "Octavia Soegyono"
+            ],
+            "Treasurer": [
+               "Lucas Pickup"
+            ],
+            "Arc Delegate": [
+               "Karl Krauth"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Jashank Jeremy"
+            ],
+            "CompClub": [
+               "Jason Lim"
+            ],
+            "Dev": [
+               "George Caley"
+            ],
+            "DevSpace": [
+               "Matthew McEwen",
+               "Joshua Elliott"
+            ],
+            "Publicity": [
+               "Lavender Chan"
+            ],
+            "Social": [
+               "Steven Strijakov",
+               "Jake Bloom"
+            ],
+            "Student Network": [
+               "Christopher Manouvrier"
+            ],
+            "Talks and Workshops": [
+               "John Wiseheart",
+               "David Sison"
+            ]
+         }
       }
    },
-   "2014": {
-      "Executives": {
-         "Co-Presidents": [
-            "Vincent Wong",
-            "Pierre Estephan"
-         ],
-         "Secretary": [
-            "Caroline Cham"
-         ],
-         "Treasurer": [
-            "Matthew Moss"
-         ],
-         "Arc Delegate": [
-            "Lavender Chan"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Angelo Tamayo"
-         ],
-         "Dev": [
-            "Vincent Tran",
-            "John Wiseheart"
-         ],
-         "High School": [
-            "Vanessa Ung",
-            "Mrinal Chakravarthy"
-         ],
-         "Publicity": [
-            "Davina Adisusila"
-         ],
-         "Social": [
-            "Lucas Pickup",
-            "Oliver Tan"
-         ],
-         "Tech": [
-            "Karl Krauth"
-         ]
+   {
+      "year": "2014",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Vincent Wong",
+               "Pierre Estephan"
+            ],
+            "Secretary": [
+               "Caroline Cham"
+            ],
+            "Treasurer": [
+               "Matthew Moss"
+            ],
+            "Arc Delegate": [
+               "Lavender Chan"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Angelo Tamayo"
+            ],
+            "Dev": [
+               "Vincent Tran",
+               "John Wiseheart"
+            ],
+            "High School": [
+               "Vanessa Ung",
+               "Mrinal Chakravarthy"
+            ],
+            "Publicity": [
+               "Davina Adisusila"
+            ],
+            "Social": [
+               "Lucas Pickup",
+               "Oliver Tan"
+            ],
+            "Tech": [
+               "Karl Krauth"
+            ]
+         }
       }
    },
-   "2013": {
-      "Executives": {
-         "Co-Presidents": [
-            "Christopher Manouvrier",
-            "Beth Crane"
-         ],
-         "Secretary": [
-            "Robert Newey"
-         ],
-         "Treasurer": [
-            "Luke Tsekouras"
-         ],
-         "Arc Delegate": [
-            "William Korteland"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Wen Di Lim"
-         ],
-         "Dev": [
-            "Mathew Moss"
-         ],
-         "High School": [
-            "Peter Camilleri",
-            "Samuel Li"
-         ],
-         "Publicity": [
-            "Caroline Cham"
-         ],
-         "Social": [
-            "Evelyn Chensen"
-         ],
-         "Tech": [
-            "Pierre Estephan"
-         ]
+   {
+      "year": "2013",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Christopher Manouvrier",
+               "Beth Crane"
+            ],
+            "Secretary": [
+               "Robert Newey"
+            ],
+            "Treasurer": [
+               "Luke Tsekouras"
+            ],
+            "Arc Delegate": [
+               "William Korteland"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Wen Di Lim"
+            ],
+            "Dev": [
+               "Mathew Moss"
+            ],
+            "High School": [
+               "Peter Camilleri",
+               "Samuel Li"
+            ],
+            "Publicity": [
+               "Caroline Cham"
+            ],
+            "Social": [
+               "Evelyn Chensen"
+            ],
+            "Tech": [
+               "Pierre Estephan"
+            ]
+         }
       }
    },
-   "2012": {
-      "Executives": {
-         "Co-Presidents": [
-            "Sean Harris",
-            "Sam Li"
-         ],
-         "Secretary": [
-            "Bethany Crane"
-         ],
-         "Treasurer": [
-            "Dan Padilha"
-         ],
-         "Arc Delegate": [
-            "Pauline Koh"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Ritwik Roy"
-         ],
-         "Dev": [
-            "Dylan Kelly",
-            "Chris Manouvrier"
-         ],
-         "Publicity": [
-            "Weng Sern Loh"
-         ],
-         "Social": [
-            "Youssef Hunter",
-            "Symphony Wong"
-         ],
-         "Tech": [
-            "Patrick Chung"
-         ]
+   {
+      "year": "2012",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Sean Harris",
+               "Sam Li"
+            ],
+            "Secretary": [
+               "Bethany Crane"
+            ],
+            "Treasurer": [
+               "Dan Padilha"
+            ],
+            "Arc Delegate": [
+               "Pauline Koh"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Ritwik Roy"
+            ],
+            "Dev": [
+               "Dylan Kelly",
+               "Chris Manouvrier"
+            ],
+            "Publicity": [
+               "Weng Sern Loh"
+            ],
+            "Social": [
+               "Youssef Hunter",
+               "Symphony Wong"
+            ],
+            "Tech": [
+               "Patrick Chung"
+            ]
+         }
       }
    },
-   "2011": {
-      "Executives": {
-         "Co-Presidents": [
-            "Aditya Keswani",
-            "Peter Milston"
-         ],
-         "Secretary": [
-            "Natalie Wong"
-         ],
-         "Treasurer": [
-            "Youssef Hunter"
-         ],
-         "Arc Delegate": [
-            "Dan Padilha"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Timothy Wiley"
-         ],
-         "Social": [
-            "Sam Li"
-         ],
-         "Sysadmin": [
-            "Maxwell Swadling"
-         ],
-         "Tech": [
-            "Ritwik Roy"
-         ]
+   {
+      "year": "2011",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Aditya Keswani",
+               "Peter Milston"
+            ],
+            "Secretary": [
+               "Natalie Wong"
+            ],
+            "Treasurer": [
+               "Youssef Hunter"
+            ],
+            "Arc Delegate": [
+               "Dan Padilha"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Timothy Wiley"
+            ],
+            "Social": [
+               "Sam Li"
+            ],
+            "Sysadmin": [
+               "Maxwell Swadling"
+            ],
+            "Tech": [
+               "Ritwik Roy"
+            ]
+         }
       }
    },
-   "2010": {
-      "Executives": {
-         "Co-Presidents": [
-            "Samantha Ho/Jayen Ashar",
-            "Prashant Varanasi"
-         ],
-         "Secretary": [
-            "Belinda Teh"
-         ],
-         "Treasurer": [
-            "Simonne Mautner"
-         ],
-         "Arc Delegate": [
-            "Justin Wong"
-         ]
-      },
-      "Heads": {
-         "Beta": [
-            "Charles Ma"
-         ],
-         "Publicity": [
-            "Aditya Keswani"
-         ],
-         "Social": [
-            "Natalie Wong"
-         ],
-         "Sysadmin": [
-            "Robert Massaioli"
-         ],
-         "Tech": [
-            "Carl Chatfield",
-            "Maxwell Swadling",
-            "Yongki Yusmanthia"
-         ]
+   {
+      "year": "2010",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Samantha Ho/Jayen Ashar",
+               "Prashant Varanasi"
+            ],
+            "Secretary": [
+               "Belinda Teh"
+            ],
+            "Treasurer": [
+               "Simonne Mautner"
+            ],
+            "Arc Delegate": [
+               "Justin Wong"
+            ]
+         },
+         "Heads": {
+            "Beta": [
+               "Charles Ma"
+            ],
+            "Publicity": [
+               "Aditya Keswani"
+            ],
+            "Social": [
+               "Natalie Wong"
+            ],
+            "Sysadmin": [
+               "Robert Massaioli"
+            ],
+            "Tech": [
+               "Carl Chatfield",
+               "Maxwell Swadling",
+               "Yongki Yusmanthia"
+            ]
+         }
       }
    },
-   "2009": {
-      "Executives": {
-         "Co-Presidents": [
-            "Luke Swithenbank",
-            "Cassandra Hill"
-         ],
-         "Secretary": [
-            "Emily Siow"
-         ],
-         "Treasurer": [
-            "Simonne Mautner"
-         ],
-         "Arc Delegate": [
-            "David Claridge"
-         ]
-      },
-      "Heads": {
-         "Publicity": [
-            "Phys Schmidtke"
-         ],
-         "Social": [
-            "Ben Lambert-Smith"
-         ],
-         "Sysadmin": [
-            "Prashant Varanasi"
-         ],
-         "Tech": [
-            "Jayen Ashar"
-         ],
-         "The Switch": [
-            "Jeremy Apthorp"
-         ],
-         "Web": [
-            "Stephen Cossell"
-         ]
+   {
+      "year": "2009",
+      "data": {
+         "Executives": {
+            "Co-Presidents": [
+               "Luke Swithenbank",
+               "Cassandra Hill"
+            ],
+            "Secretary": [
+               "Emily Siow"
+            ],
+            "Treasurer": [
+               "Simonne Mautner"
+            ],
+            "Arc Delegate": [
+               "David Claridge"
+            ]
+         },
+         "Heads": {
+            "Publicity": [
+               "Phys Schmidtke"
+            ],
+            "Social": [
+               "Ben Lambert-Smith"
+            ],
+            "Sysadmin": [
+               "Prashant Varanasi"
+            ],
+            "Tech": [
+               "Jayen Ashar"
+            ],
+            "The Switch": [
+               "Jeremy Apthorp"
+            ],
+            "Web": [
+               "Stephen Cossell"
+            ]
+         }
       }
    },
-   "2008": {
-      "Executives": {
-         "President": [
-            "David Claridge"
-         ],
-         "Vice President": [
-            "Martin Mao"
-         ],
-         "Secretary": [
-            "Elizabeth O'Loughlin"
-         ],
-         "Treasurer": [
-            "Rhys Schmidtke"
-         ],
-         "Arc Delegate": [
-            "Chaitanya Manapragada"
-         ]
-      },
-      "Officers": {
-         "Technical": [
-            "V. Ramana Kirubagaran"
-         ],
-         "Assistant Technical": [
-            "Prashant Varanasi",
-            "Dean Berwick"
-         ],
-         "Publicity": [
-            "Mervin Sayseng"
-         ],
-         "Social": [
-            "Stuart Robinson",
-            "Jayen Ashar",
-            "Anna Lyons"
-         ]
-      },
-      "Representatives": {
-         "Software Engineering": [
-            "Susan Shi"
-         ],
-         "Computer Science": [
-            "Matthew Conolly"
-         ],
-         "Computer Engineering": [
-            "Christopher Bailey"
-         ],
-         "Postgraduate": [
-            "Toby Rahilly"
-         ],
-         "First Year": [
-            "Robert Massaioli",
-            "Luke Swithenbank"
-         ],
-         "The Switch Working Group": [
-            "Adam Brimo",
-            "Sam Gentle"
-         ]
+   {
+      "year": "2008",
+      "data": {
+         "Executives": {
+            "President": [
+               "David Claridge"
+            ],
+            "Vice President": [
+               "Martin Mao"
+            ],
+            "Secretary": [
+               "Elizabeth O'Loughlin"
+            ],
+            "Treasurer": [
+               "Rhys Schmidtke"
+            ],
+            "Arc Delegate": [
+               "Chaitanya Manapragada"
+            ]
+         },
+         "Officers": {
+            "Technical": [
+               "V. Ramana Kirubagaran"
+            ],
+            "Assistant Technical": [
+               "Prashant Varanasi",
+               "Dean Berwick"
+            ],
+            "Publicity": [
+               "Mervin Sayseng"
+            ],
+            "Social": [
+               "Stuart Robinson",
+               "Jayen Ashar",
+               "Anna Lyons"
+            ]
+         },
+         "Representatives": {
+            "Software Engineering": [
+               "Susan Shi"
+            ],
+            "Computer Science": [
+               "Matthew Conolly"
+            ],
+            "Computer Engineering": [
+               "Christopher Bailey"
+            ],
+            "Postgraduate": [
+               "Toby Rahilly"
+            ],
+            "First Year": [
+               "Robert Massaioli",
+               "Luke Swithenbank"
+            ],
+            "The Switch Working Group": [
+               "Adam Brimo",
+               "Sam Gentle"
+            ]
+         }
       }
    },
-   "2007": {
-      "Executives": {
-         "President": [
-            "Stephen Cossell"
-         ],
-         "Vice President": [
-            "Chris Macauley"
-         ],
-         "Secretary": [
-            "Alex Kuptsov"
-         ],
-         "Treasurer": [
-            "Mitchell Reid"
-         ]
-      },
-      "Officers": {
-         "Technical": [
-            "V. Ramana Kirubagaran"
-         ],
-         "Assistant Technical": [
-            "Yose Widjaja",
-            "Suwandy Tjin"
-         ],
-         "Publicity": [
-            "Mervin Sayseng"
-         ],
-         "Social": [
-            "Rupert Shuttleworth",
-            "Fionnbharr Davies"
-         ]
-      },
-      "Representatives": {
-         "Software Engineering": [
-            "Andrew John Clayphan"
-         ],
-         "Computer Science": [
-            "Glen Trevor Kelley"
-         ],
-         "Computer Engineering": [
-            "Andrew Bastardo"
-         ],
-         "First Year": [
-            "David Claridge",
-            "Charissa Upcroft"
-         ]
+   {
+      "year": "2007",
+      "data": {
+         "Executives": {
+            "President": [
+               "Stephen Cossell"
+            ],
+            "Vice President": [
+               "Chris Macauley"
+            ],
+            "Secretary": [
+               "Alex Kuptsov"
+            ],
+            "Treasurer": [
+               "Mitchell Reid"
+            ]
+         },
+         "Officers": {
+            "Technical": [
+               "V. Ramana Kirubagaran"
+            ],
+            "Assistant Technical": [
+               "Yose Widjaja",
+               "Suwandy Tjin"
+            ],
+            "Publicity": [
+               "Mervin Sayseng"
+            ],
+            "Social": [
+               "Rupert Shuttleworth",
+               "Fionnbharr Davies"
+            ]
+         },
+         "Representatives": {
+            "Software Engineering": [
+               "Andrew John Clayphan"
+            ],
+            "Computer Science": [
+               "Glen Trevor Kelley"
+            ],
+            "Computer Engineering": [
+               "Andrew Bastardo"
+            ],
+            "First Year": [
+               "David Claridge",
+               "Charissa Upcroft"
+            ]
+         }
       }
    }
-}
+]

--- a/frontend/src/assets/execs_directs.json
+++ b/frontend/src/assets/execs_directs.json
@@ -57,5 +57,570 @@
             "Michael Gribben"
          ]
       }
+   },
+   "2019": {
+      "Executives": {
+         "Co-Presidents": [
+            "Alli Murray",
+            "Siddhant Virmani"
+         ],
+         "Secretary": [
+            "Celine Tye"
+         ],
+         "Treasurer": [
+            "Gary Bai (replacing Rachel Liang)"
+         ],
+         "Arc Delegate": [
+            "Peter Nguyen"
+         ]
+      },
+      "Directors": {
+         "Careers": [
+            "Sam Push",
+            "Sophia Lin"
+         ],
+         "CompClub": [
+            "Jeremy Chiu",
+            "Teresa Feng"
+         ],
+         "Marketing": [
+            "Amy Luo",
+            "Taiyue Tan"
+         ],
+         "Media": [
+            "Adrian Martinez",
+            "Mehri Amin"
+         ],
+         "Professional Development & Networking": [
+            "Apurva Shukla"
+         ],
+         "Social Events": [
+            "Selina Chua",
+            "Nathan Ellis"
+         ],
+         "Software Projects": [
+            "Shane Kadish",
+            "Tom Kunc"
+         ],
+         "Student Network": [
+            "Tammy Zhong"
+         ],
+         "Workshops & Academics": [
+            "Oliver Dolk"
+         ]
+      }
+   },
+   "2018": {
+      "Executives": {
+         "Co-Presidents": [
+            "Ofir Zeevi",
+            "Andrew Vo"
+         ],
+         "Secretary": [
+            "Andrew Kaploun"
+         ],
+         "Treasurer": [
+            "Martin Minh Le"
+         ],
+         "Arc Delegate": [
+            "Raiyan Zubair"
+         ]
+      },
+      "Directors": {
+         "CompClub": [
+            "Peter Arnott",
+            "Lillian Guo"
+         ],
+         "Marketing": [
+            "Celine Tye",
+            "Sheng An Zhang"
+         ],
+         "Professional Development": [
+            "James Treloar"
+         ],
+         "Publications": [
+            "Siddhant Virmani"
+         ],
+         "Social Events": [
+            "Mark Sonnenschein",
+            "Sampath Somanchi"
+         ],
+         "Software Projects": [
+            "Amri Chamela"
+         ],
+         "Sponsored Events": [
+            "Gary Bai",
+            "Conway Ying"
+         ],
+         "Student Network": [
+            "Alli Murray"
+         ],
+         "Workshops & Academics": [
+            "Nicholas Malecki"
+         ]
+      }
+   },
+   "2017": {
+      "Executives": {
+         "Co-Presidents": [
+            "Nicola Gibson",
+            "Adam Tizzone"
+         ],
+         "Secretary": [
+            "Martin Le"
+         ],
+         "Treasurer": [
+            "Jesse Zhang"
+         ],
+         "Arc Delegate": [
+            "Weilon Ying"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Melissa Zhang"
+         ],
+         "CompClub": [
+            "Nethan Tran",
+            "Angelo Yan"
+         ],
+         "Dev": [
+            "Daniel Cameron"
+         ],
+         "DevSpace": [
+            "Inura De Zoysa"
+         ],
+         "Publicity": [
+            "Vivian Dang"
+         ],
+         "Social": [
+            "Andrew Vo",
+            "Ofir Zeevi"
+         ],
+         "Student Network": [
+            "David Sison"
+         ],
+         "Talks": [
+            "Raiyan Zubair"
+         ],
+         "Workshops": [
+            "Mitch Ball"
+         ]
+      }
+   },
+   "2016": {
+      "Executives": {
+         "Co-Presidents": [
+            "Lavender Chan",
+            "Jake Bloom"
+         ],
+         "Secretary": [
+            "Carmen Wang"
+         ],
+         "Treasurer": [
+            "Steven Strijakov"
+         ],
+         "Arc Delegate": [
+            "David Sison"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Jayden Tilbrook",
+            "Emily Olorin"
+         ],
+         "CompClub": [
+            "Joseph Hilsberg"
+         ],
+         "Dev": [
+            "Nicholas Whyte"
+         ],
+         "DevSpace": [
+            "John Wiseheart"
+         ],
+         "Publicity": [
+            "Nicola Gibson"
+         ],
+         "Social": [
+            "George Mountakis",
+            "Jathurson Subachandran"
+         ],
+         "Student Network": [
+            "Jesse Zhang"
+         ],
+         "Talks and Workshops": [
+            "Adam Tizzone",
+            "Daniel Phillips"
+         ]
+      }
+   },
+   "2015": {
+      "Executives": {
+         "Co-Presidents": [
+            "Oliver Tan",
+            "Davina Adisusila"
+         ],
+         "Secretary": [
+            "Octavia Soegyono"
+         ],
+         "Treasurer": [
+            "Lucas Pickup"
+         ],
+         "Arc Delegate": [
+            "Karl Krauth"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Jashank Jeremy"
+         ],
+         "CompClub": [
+            "Jason Lim"
+         ],
+         "Dev": [
+            "George Caley"
+         ],
+         "DevSpace": [
+            "Matthew McEwen",
+            "Joshua Elliott"
+         ],
+         "Publicity": [
+            "Lavender Chan"
+         ],
+         "Social": [
+            "Steven Strijakov",
+            "Jake Bloom"
+         ],
+         "Student Network": [
+            "Christopher Manouvrier"
+         ],
+         "Talks and Workshops": [
+            "John Wiseheart",
+            "David Sison"
+         ]
+      }
+   },
+   "2014": {
+      "Executives": {
+         "Co-Presidents": [
+            "Vincent Wong",
+            "Pierre Estephan"
+         ],
+         "Secretary": [
+            "Caroline Cham"
+         ],
+         "Treasurer": [
+            "Matthew Moss"
+         ],
+         "Arc Delegate": [
+            "Lavender Chan"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Angelo Tamayo"
+         ],
+         "Dev": [
+            "Vincent Tran",
+            "John Wiseheart"
+         ],
+         "High School": [
+            "Vanessa Ung",
+            "Mrinal Chakravarthy"
+         ],
+         "Publicity": [
+            "Davina Adisusila"
+         ],
+         "Social": [
+            "Lucas Pickup",
+            "Oliver Tan"
+         ],
+         "Tech": [
+            "Karl Krauth"
+         ]
+      }
+   },
+   "2013": {
+      "Executives": {
+         "Co-Presidents": [
+            "Christopher Manouvrier",
+            "Beth Crane"
+         ],
+         "Secretary": [
+            "Robert Newey"
+         ],
+         "Treasurer": [
+            "Luke Tsekouras"
+         ],
+         "Arc Delegate": [
+            "William Korteland"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Wen Di Lim"
+         ],
+         "Dev": [
+            "Mathew Moss"
+         ],
+         "High School": [
+            "Peter Camilleri",
+            "Samuel Li"
+         ],
+         "Publicity": [
+            "Caroline Cham"
+         ],
+         "Social": [
+            "Evelyn Chensen"
+         ],
+         "Tech": [
+            "Pierre Estephan"
+         ]
+      }
+   },
+   "2012": {
+      "Executives": {
+         "Co-Presidents": [
+            "Sean Harris",
+            "Sam Li"
+         ],
+         "Secretary": [
+            "Bethany Crane"
+         ],
+         "Treasurer": [
+            "Dan Padilha"
+         ],
+         "Arc Delegate": [
+            "Pauline Koh"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Ritwik Roy"
+         ],
+         "Dev": [
+            "Dylan Kelly",
+            "Chris Manouvrier"
+         ],
+         "Publicity": [
+            "Weng Sern Loh"
+         ],
+         "Social": [
+            "Youssef Hunter",
+            "Symphony Wong"
+         ],
+         "Tech": [
+            "Patrick Chung"
+         ]
+      }
+   },
+   "2011": {
+      "Executives": {
+         "Co-Presidents": [
+            "Aditya Keswani",
+            "Peter Milston"
+         ],
+         "Secretary": [
+            "Natalie Wong"
+         ],
+         "Treasurer": [
+            "Youssef Hunter"
+         ],
+         "Arc Delegate": [
+            "Dan Padilha"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Timothy Wiley"
+         ],
+         "Social": [
+            "Sam Li"
+         ],
+         "Sysadmin": [
+            "Maxwell Swadling"
+         ],
+         "Tech": [
+            "Ritwik Roy"
+         ]
+      }
+   },
+   "2010": {
+      "Executives": {
+         "Co-Presidents": [
+            "Samantha Ho/Jayen Ashar",
+            "Prashant Varanasi"
+         ],
+         "Secretary": [
+            "Belinda Teh"
+         ],
+         "Treasurer": [
+            "Simonne Mautner"
+         ],
+         "Arc Delegate": [
+            "Justin Wong"
+         ]
+      },
+      "Heads": {
+         "Beta": [
+            "Charles Ma"
+         ],
+         "Publicity": [
+            "Aditya Keswani"
+         ],
+         "Social": [
+            "Natalie Wong"
+         ],
+         "Sysadmin": [
+            "Robert Massaioli"
+         ],
+         "Tech": [
+            "Carl Chatfield",
+            "Maxwell Swadling",
+            "Yongki Yusmanthia"
+         ]
+      }
+   },
+   "2009": {
+      "Executives": {
+         "Co-Presidents": [
+            "Luke Swithenbank",
+            "Cassandra Hill"
+         ],
+         "Secretary": [
+            "Emily Siow"
+         ],
+         "Treasurer": [
+            "Simonne Mautner"
+         ],
+         "Arc Delegate": [
+            "David Claridge"
+         ]
+      },
+      "Heads": {
+         "Publicity": [
+            "Phys Schmidtke"
+         ],
+         "Social": [
+            "Ben Lambert-Smith"
+         ],
+         "Sysadmin": [
+            "Prashant Varanasi"
+         ],
+         "Tech": [
+            "Jayen Ashar"
+         ],
+         "The Switch": [
+            "Jeremy Apthorp"
+         ],
+         "Web": [
+            "Stephen Cossell"
+         ]
+      }
+   },
+   "2008": {
+      "Executives": {
+         "President": [
+            "David Claridge"
+         ],
+         "Vice President": [
+            "Martin Mao"
+         ],
+         "Secretary": [
+            "Elizabeth O'Loughlin"
+         ],
+         "Treasurer": [
+            "Rhys Schmidtke"
+         ],
+         "Arc Delegate": [
+            "Chaitanya Manapragada"
+         ]
+      },
+      "Officers": {
+         "Technical": [
+            "V. Ramana Kirubagaran"
+         ],
+         "Assistant Technical": [
+            "Prashant Varanasi",
+            "Dean Berwick"
+         ],
+         "Publicity": [
+            "Mervin Sayseng"
+         ],
+         "Social": [
+            "Stuart Robinson",
+            "Jayen Ashar",
+            "Anna Lyons"
+         ]
+      },
+      "Representatives": {
+         "Software Engineering": [
+            "Susan Shi"
+         ],
+         "Computer Science": [
+            "Matthew Conolly"
+         ],
+         "Computer Engineering": [
+            "Christopher Bailey"
+         ],
+         "Postgraduate": [
+            "Toby Rahilly"
+         ],
+         "First Year": [
+            "Robert Massaioli",
+            "Luke Swithenbank"
+         ],
+         "The Switch Working Group": [
+            "Adam Brimo",
+            "Sam Gentle"
+         ]
+      }
+   },
+   "2007": {
+      "Executives": {
+         "President": [
+            "Stephen Cossell"
+         ],
+         "Vice President": [
+            "Chris Macauley"
+         ],
+         "Secretary": [
+            "Alex Kuptsov"
+         ],
+         "Treasurer": [
+            "Mitchell Reid"
+         ]
+      },
+      "Officers": {
+         "Technical": [
+            "V. Ramana Kirubagaran"
+         ],
+         "Assistant Technical": [
+            "Yose Widjaja",
+            "Suwandy Tjin"
+         ],
+         "Publicity": [
+            "Mervin Sayseng"
+         ],
+         "Social": [
+            "Rupert Shuttleworth",
+            "Fionnbharr Davies"
+         ]
+      },
+      "Representatives": {
+         "Software Engineering": [
+            "Andrew John Clayphan"
+         ],
+         "Computer Science": [
+            "Glen Trevor Kelley"
+         ],
+         "Computer Engineering": [
+            "Andrew Bastardo"
+         ],
+         "First Year": [
+            "David Claridge",
+            "Charissa Upcroft"
+         ]
+      }
    }
 }

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -264,6 +264,31 @@
         </v-expansion-panel>
       </v-expansion-panels>
     </v-container>
+
+    <!-- History -->
+    <v-container ref="content-start" style="padding: 20px 30px 10px 30px">
+      <HeaderTitle title="History"></HeaderTitle>
+      <p>
+        CSESoc was formed in October 2006 from the old CompSoc and SESoc societies. CompSoc helped represent the interest 
+        of students studying Computer Engineering, Computer Science and postgraduate courses, while SESoc was the 
+        representative body for Software Engineering students. Both societies provided technical and social support to 
+        their members. In the best interest of everyone, the societies merged to provide a better experience to all CSE 
+        students.
+      </p>
+      <p>
+        CSESoc now represents students enrolled in Computer Science, Computer Engineering, Software Engineering, 
+        Bioinformatics Engineering, or a post‐graduate program administered by CSE (research or coursework).
+      </p>
+      <p>
+        Even today CSESoc continues to be an integral part of the student experience. Many students make the most of their 
+        time at university by joining a working group in first year to get a taste of the society. If you are enthusiastic 
+        and interested you can nominate yourself or be nominated for a position in the Exec at the end of the year.
+      </p>
+      <p>
+        Being part of a society is a great way to meet new people and gain extra skills that employers look for in the 
+        industry.
+      </p>
+    </v-container>
   </v-app>
 </template>
 

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -1,7 +1,9 @@
 <template>
-  <div>
-    <div class="content">
-      <h1 class="mt-12">#!/ABOUT</h1>
+  <v-app>
+
+    <!-- About -->
+    <v-container ref="content-start" style="padding: 20px 30px 10px 30px">
+      <HeaderTitle title="About"></HeaderTitle>
       <p>
         CSESoc is the principal representative body for computing students on campus. We are one of the biggest and most
         active societies at UNSW, catering to over 3500 CSE students spanning across degrees in
@@ -23,11 +25,147 @@
         school and industry.
         Most of all, we're here to help you settle in and have a great time at UNSW!
       </p>
-    </div>
-  </div>
+    </v-container>
+
+    <!-- Subcommittees -->
+    <v-container ref="content-start" style="padding: 20px 30px 10px 30px">
+      <HeaderTitle title="Subcommittees"></HeaderTitle>
+      <p>
+        The CSESoc Subcommittees are an integral part of CSESoc and are responsible for directly interacting with the 
+        students and sponsors through events, publications, this website, etc. Each subcommittee is run by the portfolio 
+        directors, and those directors are selected by the executive and is part of the director board.
+        The CSESoc Executive and Directors hope you have enjoyed our events and activities - so much so that you wish to 
+        get involved!
+        If you are interested in volunteering in a specific area or are thinking about running for an executive position 
+        in the future, then joining a subcom is the best way to get involved, meet other people and try something new!
+      </p>
+      <v-expansion-panels flat accordion id="show">
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Careers</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            One of the core goals of CSESoc is to provide students with a large variety of opportunities to build and 
+            diversify their careers and professional portfolios. Our members are recognised around the globe as world 
+            class computing students and many of them go on to work at an extremely wide range of organisations in an 
+            assortment of different roles.
+            <br /><br />
+            The careers team aims to imbue our members with the skills, experience, and connections needed to forge a 
+            successful career in the technology industry. We organise and host events throughout semester designed to 
+            achieve this goal - such as sponsor talks and workshops, networking nights, resume and interview workshops, 
+            hackathons, and so on. We also help manage sponsor relations, as sponsors play a key role in everything we do. 
+            This year, we're also planning on launching a number of exciting professional development initiatives, which, 
+            combined with our events, look to form a strong platform in maximising opportunities for all of our 
+            constituents.
+            <br /><br />
+            If that sounds like an amazing and meaningful role to play, then watch out for the next CSESoc recruitment drive - we're looking for passionate and dedicated people to get involved in the Careers team!
+            <br /><br />
+            Contact Email: careers@csesoc.org.au
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">CompClub</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            CompClub is the high school outreach program of the Computer Science and Engineering Society (CSESoc) at UNSW 
+            Sydney. CompClub exists to introduce high school students to the basics of Computer Science and to encourage 
+            students to study CSE. CompClub runs ​standalone workshops throughout the year at UNSW and participating high 
+            schools as well as biannual programs at UNSW known as the Summer and Winter Schools.
+            <br /><br />
+            If you are a teacher or educator who is interested in contacting us, please email us at compclub@csesoc.org.au.
+            If you are a high school student, have a look at our Winter Workshops.
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Creative</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Marketing</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            CSESoc's Marketing team is all about promoting the countless sponsored career events and the amazing social 
+            events that happen throughout uni life. The marketing team allows you to help market CSESoc to students and 
+            our sponsors. From designing merchandise, to creating a Facebook event for one of our fantastic social events, 
+            tech talks or workshops, to taking photos and videos to capture these moments in an everlasting medium. Come 
+            along, join in - all levels of experience welcome! To get involved with Marketing, lookout for the next 
+            recruitment drive.
+            <br /><br />
+            Contact Email: marketing@csesoc.org.au
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Media</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            The Media Team is responsible for cementing the CSESoc’s brand and student voice, managing content that 
+            enriches the academic, social and cultural experience of CSE students all while acting as a bridge for 
+            students ideas, opinions and advice to the wider society. Some of the type of content media is responsible for 
+            producing include but not limited to are podcasts, videos, articles and the First Year Guide.
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Socials</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            CSESoc's Social team is in charge of making university life unforgettable, fun and to forge a strong community 
+            within the society. We are responsible for the weekly barbeques, the classic Cardboard Night and Trivia 
+            Nights, as well as the renown CSESoc Cruise! We are looking for YOU to help provide new ideas and improve on 
+            our events. If you are keen on expanding your personal bubble and are looking to develop your skills, whilst 
+            making a difference to student life of CSESoc members, then look no further.
+            <br /><br />
+            Contact Email: socials@csesoc.org.au
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Software Projects</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            CSESoc is a society for computing students, so it's only fair we do some computing. The CSESoc Projects team 
+            works on projects like the society's website, and other student led initiatives. We also work with the 
+            Workshop team to run workshops, to build skills that can be applied in ours' as well as projects.
+            We want to see the Projects team grow, and give members the skills their project ideas to reality, both inside 
+            and outside the society.
+            <br /><br />
+            We encourage everyone to join the Projects team, regardless of experience level. Even if you don't feel like 
+            you can contribute technically, we want you for your ideas and your enthusiasm. Projects can be a great chance 
+            to learn some of the gaps in your knowledge that lectures might have left out, and to offer your first taste 
+            of designing and building things for the real world.
+            <br /><br />
+            Contact Email: software.projects@csesoc.org.au
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Student Network</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Workshops</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            The Workshops team organises student-run educational events throughout the year to help CSE students (and 
+            anyone else, really) make use of both new, and widely used technologies. Additionally, Workshops promotes the 
+            use of Linux through installfests by helping students set up and solve problems with Linux. This enables CSE 
+            students to go above and beyond their degree, and we want your help! Either as someone with a lot of 
+            experience to spread knowledge, or someone with a little experience to translate from 1337speak to n00bspeak, 
+            or someone with no experience to provide a roadmap of what CSE students want to know.
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-container>
+
+
+
+  </v-app>
 </template>
 
 <script>
+import HeaderTitle from '@/components/HeaderTitle';
+
+export default {
+  data: () => ({
+
+  }),
+  components: {
+    HeaderTitle
+  },
+};
 </script>
 
 <style scoped>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -233,9 +233,6 @@
         </v-expansion-panel>
       </v-expansion-panels>
     </v-container>
-
-
-
   </v-app>
 </template>
 
@@ -243,9 +240,6 @@
 import HeaderTitle from '@/components/HeaderTitle';
 
 export default {
-  data: () => ({
-
-  }),
   components: {
     HeaderTitle
   },

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -42,71 +42,51 @@
         The CSESoc Executive and Director team for 2020 is:
       </p>
 
-      <table class="table table-bordered table-striped">
-        <thead>
-          <tr><th colspan="2">
-            <h3>Executives</h3>
-          </th><th colspan="2">
-            <h3>Directors</h3>
-          </th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th width="20%">Co-Presidents</th>
-            <td width="30%">Shane Kadish<br>Tammy Zhong</td>
-            <th width="20%">Careers</th>
-            <td>Evangeline Endacott<br>Low Khye Ean<br>Nicholas Duller<br>Yan Zhai</td>
-          </tr>
-          <tr>
-            <th>Secretary</th>
-            <td>Sam Push</td>
-            <th>CompClub</th>
-            <td>Livia Wijayanti<br>Timothy Ryan</td>
-          </tr>
-          <tr>
-            <th>Treasurer</th>
-            <td>Teresa Feng</td>
-            <th>Creative</th>
-            <td>Elizabeth Zhong<br>Jia Min Guo</td>
-          </tr>
-          <tr>
-            <th>Arc Delegate</th>
-            <td>Jeremy Chiu</td>
-            <th>Marketing</th>
-            <td>Isaac Joshi<br>Jessica Feng</td>
-          </tr>
-          <tr>
-            <th>Grievance Officer</th>
-            <td>Tom Kunc</td>
-            <th>Media</th>
-            <td>Aditi Chandra<br>Clarence Shijun Feng</td>
-          </tr>
-          <tr>
-            <th>&nbsp;</th>
-            <td>&nbsp;</td>
-            <th>Socials</th>
-            <td>Frances Lee<br>Van-Roy Trinh</td>
-          </tr>
-          <tr>
-            <th>&nbsp;</th>
-            <td>&nbsp;</td>
-            <th>Software Projects</th>
-            <td>Gordon Zhong<br>Leesa Kristina Dang</td>
-          </tr>
-          <tr>
-            <th>&nbsp;</th>
-            <td>&nbsp;</td>
-            <th>Student Network</th>
-            <td>Sachin Krishnamoorthy<br>Shrey Somaiya</td>
-          </tr>
-          <tr>
-            <th>&nbsp;</th>
-            <td>&nbsp;</td>
-            <th>Workshops</th>
-            <td>Michael Gribben</td>
-          </tr>
-        </tbody>
-      </table>
+      <v-row no-gutters>
+        <v-col md="1"></v-col>
+
+        <v-col md="4">
+          <table class="table table-bordered table-striped">
+            <thead>
+              <tr><th colspan="2">
+                <h3>Executives</h3>
+              </th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="(exec, key) in this.execsDirects['2020']['Executives']" :key="key">
+                <th width="20%">{{key}}</th>
+                <td width="30%">
+                  <tr v-for="name in exec" :key="name">
+                    {{name}}
+                  </tr>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </v-col>
+
+        <v-col md="1"></v-col>
+
+        <v-col md="4">
+          <table class="table table-bordered table-striped">
+            <thead>
+              <tr><th colspan="2">
+                <h3>Directors</h3>
+              </th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="(direc, key) in this.execsDirects['2020']['Directors']" :key="key">
+                <th width="20%">{{key}}</th>
+                <td width="30%">
+                  <tr v-for="name in direc" :key="name">
+                    {{name}}
+                  </tr>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </v-col>
+      </v-row>
     </v-container>
 
     <!-- Subcommittees -->
@@ -304,9 +284,12 @@
 import HeaderTitle from '@/components/HeaderTitle';
 
 export default {
+  data: () => ({
+    execsDirects: require('@/assets/execs_directs.json')
+  }),
   components: {
     HeaderTitle
-  },
+  }
 };
 </script>
 

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -10,6 +10,8 @@
         Computer Science, Software Engineering, Bioinformatics and Computer Engineering.
         We are here to fulfil the needs of computing students and also promote computing in all
         its forms through weekly social and technical events throughout the year.
+      </p>
+      <p>
         We are a society for the students, by the students. As a CSE student, here's how we can help you:
         We organise and run weekly events, including Trivia, Movie, Poker, and Boardgame Nights, LAN Parties,
         Workshops, Code Jams, Tech Talks, and our famous Free Weekly BBQ.
@@ -23,8 +25,90 @@
         We're as passionate about computing as you are; we provide technical events to teach you new skills,
         as well as a fortnightly magazine to keep you updated on what's new and interesting within the university,
         school and industry.
+      </p>
+      <p>
         Most of all, we're here to help you settle in and have a great time at UNSW!
       </p>
+    </v-container>
+
+    <!-- Executives & Directors -->
+    <v-container ref="content-start" style="padding: 20px 30px 10px 30px">
+      <HeaderTitle title="Executives_&_Directors"></HeaderTitle>
+      <p>
+        The Executives and Directors are responsible for organising the society to make sure that things get done. Execs 
+        are elected annually by CSE students at the end of the preceding year and Directors are selected by Execs.
+      </p>
+      <p>
+        The CSESoc Executive and Director team for 2020 is:
+      </p>
+
+      <table class="table table-bordered table-striped">
+        <thead>
+          <tr><th colspan="2">
+            <h3>Executives</h3>
+          </th><th colspan="2">
+            <h3>Directors</h3>
+          </th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th width="20%">Co-Presidents</th>
+            <td width="30%">Shane Kadish<br>Tammy Zhong</td>
+            <th width="20%">Careers</th>
+            <td>Evangeline Endacott<br>Low Khye Ean<br>Nicholas Duller<br>Yan Zhai</td>
+          </tr>
+          <tr>
+            <th>Secretary</th>
+            <td>Sam Push</td>
+            <th>CompClub</th>
+            <td>Livia Wijayanti<br>Timothy Ryan</td>
+          </tr>
+          <tr>
+            <th>Treasurer</th>
+            <td>Teresa Feng</td>
+            <th>Creative</th>
+            <td>Elizabeth Zhong<br>Jia Min Guo</td>
+          </tr>
+          <tr>
+            <th>Arc Delegate</th>
+            <td>Jeremy Chiu</td>
+            <th>Marketing</th>
+            <td>Isaac Joshi<br>Jessica Feng</td>
+          </tr>
+          <tr>
+            <th>Grievance Officer</th>
+            <td>Tom Kunc</td>
+            <th>Media</th>
+            <td>Aditi Chandra<br>Clarence Shijun Feng</td>
+          </tr>
+          <tr>
+            <th>&nbsp;</th>
+            <td>&nbsp;</td>
+            <th>Socials</th>
+            <td>Frances Lee<br>Van-Roy Trinh</td>
+          </tr>
+          <tr>
+            <th>&nbsp;</th>
+            <td>&nbsp;</td>
+            <th>Software Projects</th>
+            <td>Gordon Zhong<br>Leesa Kristina Dang</td>
+          </tr>
+          <tr>
+            <th>&nbsp;</th>
+            <td>&nbsp;</td>
+            <th>Student Network</th>
+            <td>Sachin Krishnamoorthy<br>Shrey Somaiya</td>
+          </tr>
+          <tr>
+            <th>&nbsp;</th>
+            <td>&nbsp;</td>
+            <th>Workshops</th>
+            <td>Michael Gribben</td>
+          </tr>
+        </tbody>
+      </table>
+
+
     </v-container>
 
     <!-- Subcommittees -->
@@ -169,4 +253,12 @@ export default {
 </script>
 
 <style scoped>
+td {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+th {
+  padding-right: 10px;
+}
 </style>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -262,6 +262,14 @@
             interaction between the year levels and undergraduate-postgraduate.
           </v-expansion-panel-content>
         </v-expansion-panel>
+        <v-expansion-panel>
+          <v-expansion-panel-header class="title py-3">Workshops</v-expansion-panel-header>
+          <v-expansion-panel-content>
+            The Workshops team organises student-run educational events throughout the year to help CSE students (and anyone else, 
+            really) make use of both new, and widely used technologies. Additionally, Workshops promotes the use of Linux through 
+            installfests by helping students set up and solve problems with Linux.
+          </v-expansion-panel-content>
+        </v-expansion-panel>
       </v-expansion-panels>
     </v-container>
 

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -132,15 +132,11 @@
             <br /><br />
             The careers team aims to imbue our members with the skills, experience, and connections needed to forge a 
             successful career in the technology industry. We organise and host events throughout semester designed to 
-            achieve this goal - such as sponsor talks and workshops, networking nights, resume and interview workshops, 
-            hackathons, and so on. We also help manage sponsor relations, as sponsors play a key role in everything we do. 
-            This year, we're also planning on launching a number of exciting professional development initiatives, which, 
-            combined with our events, look to form a strong platform in maximising opportunities for all of our 
-            constituents.
-            <br /><br />
-            If that sounds like an amazing and meaningful role to play, then watch out for the next CSESoc recruitment drive - we're looking for passionate and dedicated people to get involved in the Careers team!
-            <br /><br />
-            Contact Email: careers@csesoc.org.au
+            achieve this goal - such as tech talks and workshops, networking nights, resume and interview workshops, 
+            hackathons, coding competitions and so on. We also help manage sponsor relations, as sponsors play a key role 
+            in everything we do. This subcommittee helps its members develop both personally and professionally as they 
+            correspond with our points of contact the worlds biggest tech companies: Google, Microsoft, Amazon, Facebook, 
+            Atlassian, Canva, etc.
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel>
@@ -152,26 +148,53 @@
             schools as well as biannual programs at UNSW known as the Summer and Winter Schools.
             <br /><br />
             If you are a teacher or educator who is interested in contacting us, please email us at compclub@csesoc.org.au.
-            If you are a high school student, have a look at our Winter Workshops.
+            If you are a high school student, keep an eye out for our Winter Workshops.
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel>
           <v-expansion-panel-header class="title py-3">Creative</v-expansion-panel-header>
           <v-expansion-panel-content>
-            
+            The Creative Team is responsible for expressing our creative freedoms whilst
+            integrating what we create fully with CSESoc branding and vision. We believe in
+            combining the logical and analytical side of CSE with creativity and artistic
+            expression. Not only this, we provide an avenue for subcom to learn something
+            new, come up with creative CSE projects and develop your creative minds.
+            <br /><br />
+            The Events Team works with other portfolios to deliver event-based design
+            demands such as banners on a request basis, focused on developing a professional
+            relationship with not only CSESoc, but more importantly our sponsored
+            companies!
+            <br /><br />
+            The Video Team handles the development of videos and editing for
+            publishing/advertising. This year we want to explore new territories of motion
+            graphics and animations to develop videos such as animated video banners,
+            informational videos and promotional videos for events.
+            <br /><br />
+            The Merchandise Team is responsible for coming up with innovative ideas for our
+            upcoming merchandise - such as stickers, hoodies and team shirts.
+            <br /><br />
+            The wildcard is an all-rounder role which covers all aspects of creative expression.
+            This includes, but not limited to, organising subcom upskilling workshops,
+            intersociety design related collaboration, general creative design and logo design.
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel>
           <v-expansion-panel-header class="title py-3">Marketing</v-expansion-panel-header>
           <v-expansion-panel-content>
-            CSESoc's Marketing team is all about promoting the countless sponsored career events and the amazing social 
-            events that happen throughout uni life. The marketing team allows you to help market CSESoc to students and 
-            our sponsors. From designing merchandise, to creating a Facebook event for one of our fantastic social events, 
-            tech talks or workshops, to taking photos and videos to capture these moments in an everlasting medium. Come 
-            along, join in - all levels of experience welcome! To get involved with Marketing, lookout for the next 
-            recruitment drive.
+            The Marketing team is responsible for the effective promotion and marketing of
+            CSESoc and its events. CSESoc is a premier society at UNSW so we aim to ensure
+            that our image is continually strengthened while delivering valuable events and
+            opportunities to CSE students.
             <br /><br />
-            Contact Email: marketing@csesoc.org.au
+            The Social Media team will be in charge of the creation and promotion of events
+            and opportunities provided by the CSESoc society, sometimes including content
+            creation. We also look at reviewing current and creating new strategies to
+            maximise our reach. We also collaborate with other portfolios to ensure maximum
+            exposure and success of events.
+            <br /><br />
+            The Photography/Video Team is a great place for those who are creatively inclined,
+            the role will include taking photos and videos at social events, creating and
+            managing media, and creating promotional content.
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel>
@@ -186,47 +209,57 @@
         <v-expansion-panel>
           <v-expansion-panel-header class="title py-3">Socials</v-expansion-panel-header>
           <v-expansion-panel-content>
-            CSESoc's Social team is in charge of making university life unforgettable, fun and to forge a strong community 
-            within the society. We are responsible for the weekly barbeques, the classic Cardboard Night and Trivia 
-            Nights, as well as the renown CSESoc Cruise! We are looking for YOU to help provide new ideas and improve on 
-            our events. If you are keen on expanding your personal bubble and are looking to develop your skills, whilst 
-            making a difference to student life of CSESoc members, then look no further.
+            The Socials Team plans, organises and executes all of CSESoc’s social events -
+            including the weekly BBQs, pub crawl, ice skating, cardboard night, and lots more.
+            In planning these events, we do our best to not only create opportunities for
+            students across all years to form friendships, but to also create spaces where
+            these bonds can continue to cultivate throughout their entire university careers.
+            The best part about being part of this team is how rewarding it feels to watch as
+            everything comes together and as everyone enjoys themselves within an
+            environment that we created! In addition, you will also be joining a family of about
+            50 people, and we will be going on trips and doing bonding activities together.
+            Being part of the Socials Team is also a good way to develop leadership, teamwork
+            and communication skills, and is something employers love to see on a resume.
             <br /><br />
-            Contact Email: socials@csesoc.org.au
+            This year, we hope to expand our reach by engaging with our members more,
+            doing our best to instigate friendships between strangers, and collaborating with
+            our societies (and potentially other universities). We are looking for people from
+            all years who are committed, passionate and excited about meeting new people
+            and fostering these bonds!
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel>
-          <v-expansion-panel-header class="title py-3">Software Projects</v-expansion-panel-header>
+          <v-expansion-panel-header class="title py-3">Projects</v-expansion-panel-header>
           <v-expansion-panel-content>
-            CSESoc is a society for computing students, so it's only fair we do some computing. The CSESoc Projects team 
-            works on projects like the society's website, and other student led initiatives. We also work with the 
-            Workshop team to run workshops, to build skills that can be applied in ours' as well as projects.
-            We want to see the Projects team grow, and give members the skills their project ideas to reality, both inside 
-            and outside the society.
+            CSESoc is a society for computing students, so it's only fair we do some computing. 
+            The Projects Team is a place to create student-led projects with the goal of building
+            transferable technical and soft skills so our members can thrive in university, work and
+            anything else you want to do.
+            <br /><br />
+            These projects are normally built for university students, which means when these
+            projects are completed, they will be used by yourself and your peers! It is a great way to
+            get involved in CSESoc while branching out and trying a technology or language that you
+            are interested in.
             <br /><br />
             We encourage everyone to join the Projects team, regardless of experience level. Even if you don't feel like 
             you can contribute technically, we want you for your ideas and your enthusiasm. Projects can be a great chance 
             to learn some of the gaps in your knowledge that lectures might have left out, and to offer your first taste 
             of designing and building things for the real world.
-            <br /><br />
-            Contact Email: software.projects@csesoc.org.au
           </v-expansion-panel-content>
         </v-expansion-panel>
         <v-expansion-panel>
           <v-expansion-panel-header class="title py-3">Student Network</v-expansion-panel-header>
           <v-expansion-panel-content>
-            
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-        <v-expansion-panel>
-          <v-expansion-panel-header class="title py-3">Workshops</v-expansion-panel-header>
-          <v-expansion-panel-content>
-            The Workshops team organises student-run educational events throughout the year to help CSE students (and 
-            anyone else, really) make use of both new, and widely used technologies. Additionally, Workshops promotes the 
-            use of Linux through installfests by helping students set up and solve problems with Linux. This enables CSE 
-            students to go above and beyond their degree, and we want your help! Either as someone with a lot of 
-            experience to spread knowledge, or someone with a little experience to translate from 1337speak to n00bspeak, 
-            or someone with no experience to provide a roadmap of what CSE students want to know.
+            The Stunet Team works as part of the Socials portfolio to better the student experience!
+            We aim to help incoming CSE students to integrate into life in CSE at UNSW,
+            facilitate students connecting with each other, combat the feeling of "imposters
+            syndrome" felt by new CSE students, elevate well-being of CSE students in general.
+            We run workshops, mentoring programs, study sessions, and help facilitate CSE
+            Events.
+            <br /><br />
+            Stunet works closely and Socials - and our role is quite diverse! Additionally, this year
+            we are hoping to expand our program by improving cohesion and increase
+            interaction between the year levels and undergraduate-postgraduate.
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -43,42 +43,18 @@
       </p>
 
       <v-row no-gutters>
-        <v-col md="1"></v-col>
-
-        <v-col md="4">
-          <table class="table table-bordered table-striped">
+        <v-col v-for="(tierValue, tierName) in this.execsDirects['2020']" :key="tierName" md="4" style="margin: 0px 50px">
+          <table>
             <thead>
               <tr><th colspan="2">
-                <h3>Executives</h3>
+                <h3>{{tierName}}</h3>
               </th></tr>
             </thead>
             <tbody>
-              <tr v-for="(exec, key) in this.execsDirects['2020']['Executives']" :key="key">
-                <th width="20%">{{key}}</th>
+              <tr v-for="(roleValue, roleName) in tierValue" :key="roleName">
+                <th width="20%">{{roleName}}</th>
                 <td width="30%">
-                  <tr v-for="name in exec" :key="name">
-                    {{name}}
-                  </tr>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </v-col>
-
-        <v-col md="1"></v-col>
-
-        <v-col md="4">
-          <table class="table table-bordered table-striped">
-            <thead>
-              <tr><th colspan="2">
-                <h3>Directors</h3>
-              </th></tr>
-            </thead>
-            <tbody>
-              <tr v-for="(direc, key) in this.execsDirects['2020']['Directors']" :key="key">
-                <th width="20%">{{key}}</th>
-                <td width="30%">
-                  <tr v-for="name in direc" :key="name">
+                  <tr v-for="name in roleValue" :key="name">
                     {{name}}
                   </tr>
                 </td>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -39,30 +39,43 @@
         are elected annually by CSE students at the end of the preceding year and Directors are selected by Execs.
       </p>
       <p>
-        The CSESoc Executive and Director team for 2020 is:
+        The CSESoc Executive and Director teams for the current and past years are:
       </p>
 
-      <v-row no-gutters>
-        <v-col v-for="(tierValue, tierName) in this.execsDirects['2020']" :key="tierName" md="4" style="margin: 0px 50px">
-          <table>
-            <thead>
-              <tr><th colspan="2">
-                <h3>{{tierName}}</h3>
-              </th></tr>
-            </thead>
-            <tbody>
-              <tr v-for="(roleValue, roleName) in tierValue" :key="roleName">
-                <th width="20%">{{roleName}}</th>
-                <td width="30%">
-                  <tr v-for="name in roleValue" :key="name">
-                    {{name}}
-                  </tr>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </v-col>
-      </v-row>
+      <v-tabs class="elevation-2" vertical dark>
+        <v-tabs-slider></v-tabs-slider>
+
+        <v-tab v-for="team in this.execsDirects" :key="team.year">
+          {{team.year}}
+        </v-tab>
+        <v-tab-item v-for="team in this.execsDirects" :key="team.year">
+          <v-card flat tile>
+          
+            <v-row no-gutters>
+              <v-col v-for="(tierValue, tierName) in team.data" :key="tierName" md="4" style="margin: 0px 50px">
+                <table>
+                  <thead>
+                    <tr><th colspan="2">
+                      <h3>{{tierName}}</h3>
+                    </th></tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(roleValue, roleName) in tierValue" :key="roleName">
+                      <th>{{roleName}}</th>
+                      <td>
+                        <tr v-for="name in roleValue" :key="name">
+                          {{name}}
+                        </tr>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </v-col>
+            </v-row>
+
+          </v-card>
+        </v-tab-item>
+      </v-tabs>
     </v-container>
 
     <!-- Subcommittees -->

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -107,8 +107,6 @@
           </tr>
         </tbody>
       </table>
-
-
     </v-container>
 
     <!-- Subcommittees -->


### PR DESCRIPTION
## Changes
Created the About page, containing information regarding:
- General about
- Executives & Directors
- Subcommittees
- History

## Change reason
I managed to get the exec/directs teams from past years to render dynamically from a JSON file on Vue.

## Comments
Further changes will be made to the layout of this page once the wireframe is completed. Currently, this page simply has content from the old website and the Subcommittee Recruitment Guide.
