### PR TITLE
CW-171 PR Review Guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 # Change
 
+_Please remove everything in italics._
+
 _Add a brief and concise imperative sentence on what this PR does._
 _Example: Edit PR template to improve efficiency_
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,4 @@ _Provide a brief description based on the type of change._
 
 ## Comments
 
-- Add any other comments about the PR here
+_Add any other comments about the PR here. In particular add information relating where a reviewer should start and any specific concerns that you came across._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,16 @@
-## Changes
-- List all major changes made here
+# Change
+
+_Add a brief and concise imperative sentence on what this PR does._
+_Example: Edit PR template to improve efficiency_
 
 ## Change reason
-List the reason you are making the change here.
+
+_Provide a brief description based on the type of change._
+
+1. _Functionality - explain the problem, why the solution was chosen, and any specifics that might be worth highlighting_
+
+2. _Refactoring  - why there was a need for the change, how the changes address this problem, and steps to take to avoid the same mistakes (better documentation, another step in PR reviews, simplification of system design)_
 
 ## Comments
+
 - Add any other comments about the PR here


### PR DESCRIPTION
# Change

_Edit PR template to improve efficiency._

## Change reason

A change in the way we addressed PRs and its reviews were needed to address long wait times, quality assurance and give structure to the process to avoid conflict. This change now clarifies what needs to go into the description of a PR and how to better aid your reviewers with your code. Documentation is in place on Confluence for further clarification.

## Comments

- Please go to https://compclub.atlassian.net/wiki/spaces/Projects/pages/847511626/Project+Workflow+Guide for further guidance.
- Github labels will be introduced soon to help with streamlining PRs.

