### PR TITLE
CW-175 Cypress linting

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
 
   extends: [
     'plugin:vue/essential',
+    'plugin:cypress/recommended',
     '@vue/airbnb',
   ],
 

--- a/frontend/cypress/integration/components/preview.spec.js
+++ b/frontend/cypress/integration/components/preview.spec.js
@@ -1,24 +1,25 @@
 describe('Resources Landing Page', () => {
   beforeEach(() => {
-    cy.visit('/')
-  })
-  
+    cy.visit('/');
+  });
+
   it('finds whether the resources are displayed', () => {
     // Check if titles exists
-    cy.get('[data-cy=preview-title]').should('have.length.gt', 1)
+    cy.get('[data-cy=preview-title]').should('have.length.gt', 1);
     // Check if descriptions exists
-    cy.get('[data-cy=preview-description]').should('have.length.gt', 1)
+    cy.get('[data-cy=preview-description]').should('have.length.gt', 1);
     // Check if an initial image is visible
     // TODO: something is wrong in detecting the image
     // Something with it being lazily loaded.
-    cy.get('[data-cy=preview-image]')//.scrollIntoView().should('be.visible')
+    // cy.get('[data-cy=preview-image]').scrollIntoView().should('be.visible')
+    cy.get('[data-cy=preview-image]');
     // Check on hover works
     cy
       .get('[data-cy=preview-item]')
       .each(($li, index, $lis) => {
         cy.wrap($li).trigger('mouseover')
           .get('[data-cy=preview-image]')
-          .should('be.visible')
-      })
+          .should('be.visible');
+      });
   });
-})
+});

--- a/frontend/cypress/integration/components/preview.spec.js
+++ b/frontend/cypress/integration/components/preview.spec.js
@@ -16,7 +16,7 @@ describe('Resources Landing Page', () => {
     // Check on hover works
     cy
       .get('[data-cy=preview-item]')
-      .each(($li, index, $lis) => {
+      .each(($li) => {
         cy.wrap($li).trigger('mouseover')
           .get('[data-cy=preview-image]')
           .should('be.visible');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "babel-eslint": "^10.0.1",
     "cypress": "^4.12.1",
     "eslint": "^7.6.0",
+    "eslint-plugin-cypress": "^2.11.1",
     "eslint-plugin-vue": "^6.2.2",
     "sass": "^1.26.10",
     "sass-loader": "^9.0.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3752,6 +3752,13 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-cypress@^2.11.1:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.1.tgz#a945e2774b88211e2c706a059d431e262b5c2862"
+  integrity sha512-MxMYoReSO5+IZMGgpBZHHSx64zYPSPTpXDwsgW7ChlJTF/sA+obqRbHplxD6sBStE+g4Mi0LCLkG4t9liu//mQ==
+  dependencies:
+    globals "^11.12.0"
+
 eslint-plugin-import@^2.21.2:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
@@ -4521,7 +4528,7 @@ global-dirs@^2.0.1:
   dependencies:
     ini "^1.3.5"
 
-globals@^11.1.0:
+globals@^11.1.0, globals@^11.12.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==


### PR DESCRIPTION
# Change
Add linting capabilities for Cypress files through ESLint.

## Change reason
This was needed to improve the quality of our code by creating a standard that everyone can adhere to.

## Comments
I updated the Preview cypress file according to the new linting suggestions. In line 19 of `preview.spec.js` I removed the unused variables in that `.each` loop.