### PR TITLE
CW-177 Mailing form testing

### DIFF
--- a/frontend/cypress/integration/components/mailingForm.spec.js
+++ b/frontend/cypress/integration/components/mailingForm.spec.js
@@ -2,65 +2,69 @@ describe('Mailing forms', () => {
   it('checks labels and validation of a general form', () => {
     // Visit engage page
     cy.visit('/#/engage');
+    // Select general form tab
+    cy.get('[data-cy=general-form-tab]').click();
     // Check if name label exists
-    cy.get('[data-cy=name-label]').contains('Name *');
+    cy.get('[data-cy=general-name-label]').contains('Name *');
     // Check if email label exists
-    cy.get('[data-cy=email-label]').contains('Email *');
+    cy.get('[data-cy=general-email-label]').contains('Email *');
     // Check if message label exists
-    cy.get('[data-cy=message-label]').contains('Message *');
+    cy.get('[data-cy=general-message-label]').contains('Message *');
     // Ensure send button is disabled
-    cy.get('[data-cy=send-button]').should('be.disabled');
+    cy.get('[data-cy=general-send-button]').should('be.disabled');
     // Fill in valid name
-    cy.get('[data-cy=name-field]').type('Sergio');
+    cy.get('[data-cy=general-name-field]').type('Sergio');
     // Fill in valid email
-    cy.get('[data-cy=email-field]').type('sergio@gmail.com');
+    cy.get('[data-cy=general-email-field]').type('sergio@gmail.com');
     // Fill in valid message
-    cy.get('[data-cy=message-field]').type('message goes here');
+    cy.get('[data-cy=general-message-field]').type('message goes here');
     // Ensure send button is enabled after entering valid inputs
-    cy.get('[data-cy=send-button]').should('not.be.disabled');
+    cy.get('[data-cy=general-send-button]').should('not.be.disabled');
   });
 
   it('checks labels and validation of a sponsorship form', () => {
     // Visit sponsors page
     cy.visit('/#/sponsors');
     // Check if name label exists
-    cy.get('[data-cy=name-label]').contains('Company Name *');
+    cy.get('[data-cy=sponsorship-name-label]').contains('Company Name *');
     // Check if email label exists
-    cy.get('[data-cy=email-label]').contains('Email *');
+    cy.get('[data-cy=sponsorship-email-label]').contains('Email *');
     // Check if message label exists
-    cy.get('[data-cy=message-label]').contains('Message *');
+    cy.get('[data-cy=sponsorship-message-label]').contains('Message *');
     // Ensure send button is disabled
-    cy.get('[data-cy=send-button]').should('be.disabled');
+    cy.get('[data-cy=sponsorship-send-button]').should('be.disabled');
     // Fill in valid name
-    cy.get('[data-cy=name-field]').type('Sergio');
+    cy.get('[data-cy=sponsorship-name-field]').type('Sergio');
     // Fill in invalid email
-    cy.get('[data-cy=email-field]').type('sergio2@ema.il.c');
+    cy.get('[data-cy=sponsorship-email-field]').type('sergio2@ema.il.c');
     // Fill in valid message
-    cy.get('[data-cy=message-field]').type('message goes here');
+    cy.get('[data-cy=sponsorship-message-field]').type('message goes here');
     // Ensure send button is disabled,
     // because the email is invalid
-    cy.get('[data-cy=send-button]').should('be.disabled');
+    cy.get('[data-cy=sponsorship-send-button]').should('be.disabled');
     // Fill in valid email
-    cy.get('[data-cy=email-field]').clear().type('sergio@gmail.com');
+    cy.get('[data-cy=sponsorship-email-field]').clear().type('sergio@gmail.com');
     // Ensure send button is enabled after making the email valid
-    cy.get('[data-cy=send-button]').should('not.be.disabled');
+    cy.get('[data-cy=sponsorship-send-button]').should('not.be.disabled');
   });
 
   it('checks labels and validation of a feedback form', () => {
     // Visit engage page
     cy.visit('/#/engage');
+    // Select feedback form tab
+    cy.get('[data-cy=feedback-form-tab]').click();
     // Check if name label exists
-    cy.get('[data-cy=name-label]').contains('Name');
+    cy.get('[data-cy=feedback-name-label]').contains('Name');
     // Check if email label exists
-    cy.get('[data-cy=email-label]').contains('Email');
+    cy.get('[data-cy=feedback-email-label]').contains('Email');
     // Check if message label exists
-    cy.get('[data-cy=message-label]').contains('Message *');
+    cy.get('[data-cy=feedback-message-label]').contains('Message *');
     // Ensure send button is disabled
-    cy.get('[data-cy=send-button]').should('be.disabled');
+    cy.get('[data-cy=feedback-send-button]').should('be.disabled');
     // Fill in valid message
-    cy.get('[data-cy=message-field]').type('message goes here');
+    cy.get('[data-cy=feedback-message-field]').type('message goes here');
     // Ensure send button is enabled,
     // because the message is the only required field
-    cy.get('[data-cy=send-button]').should('not.be.disabled');
+    cy.get('[data-cy=feedback-send-button]').should('not.be.disabled');
   });
 });

--- a/frontend/cypress/integration/components/mailingForm.spec.js
+++ b/frontend/cypress/integration/components/mailingForm.spec.js
@@ -3,32 +3,64 @@ describe('Mailing forms', () => {
     // Visit engage page
     cy.visit('/#/engage');
     // Check if name label exists
-    cy.get('[data-cy=mailing-name]').contains('Name *');
+    cy.get('[data-cy=name-label]').contains('Name *');
     // Check if email label exists
-    cy.get('[data-cy=mailing-email]').contains('Email *');
+    cy.get('[data-cy=email-label]').contains('Email *');
     // Check if message label exists
-    cy.get('[data-cy=mailing-message]').contains('Message *');
+    cy.get('[data-cy=message-label]').contains('Message *');
+    // Ensure send button is disabled
+    cy.get('[data-cy=send-button]').should('be.disabled');
+    // Fill in valid name
+    cy.get('[data-cy=name-field]').type('Sergio');
+    // Fill in valid email
+    cy.get('[data-cy=email-field]').type('sergio@gmail.com');
+    // Fill in valid message
+    cy.get('[data-cy=message-field]').type('message goes here');
+    // Ensure send button is enabled after entering valid inputs
+    cy.get('[data-cy=send-button]').should('not.be.disabled');
   });
 
   it('checks labels and validation of a sponsorship form', () => {
     // Visit sponsors page
     cy.visit('/#/sponsors');
     // Check if name label exists
-    cy.get('[data-cy=mailing-name]').contains('Company Name *');
+    cy.get('[data-cy=name-label]').contains('Company Name *');
     // Check if email label exists
-    cy.get('[data-cy=mailing-email]').contains('Email *');
+    cy.get('[data-cy=email-label]').contains('Email *');
     // Check if message label exists
-    cy.get('[data-cy=mailing-message]').contains('Message *');
+    cy.get('[data-cy=message-label]').contains('Message *');
+    // Ensure send button is disabled
+    cy.get('[data-cy=send-button]').should('be.disabled');
+    // Fill in valid name
+    cy.get('[data-cy=name-field]').type('Sergio');
+    // Fill in invalid email
+    cy.get('[data-cy=email-field]').type('sergio2@ema.il.c');
+    // Fill in valid message
+    cy.get('[data-cy=message-field]').type('message goes here');
+    // Ensure send button is disabled,
+    // because the email is invalid
+    cy.get('[data-cy=send-button]').should('be.disabled');
+    // Fill in valid email
+    cy.get('[data-cy=email-field]').clear().type('sergio@gmail.com');
+    // Ensure send button is enabled after making the email valid
+    cy.get('[data-cy=send-button]').should('not.be.disabled');
   });
 
   it('checks labels and validation of a feedback form', () => {
     // Visit engage page
     cy.visit('/#/engage');
     // Check if name label exists
-    cy.get('[data-cy=mailing-name]').contains('Name');
+    cy.get('[data-cy=name-label]').contains('Name');
     // Check if email label exists
-    cy.get('[data-cy=mailing-email]').contains('Email');
+    cy.get('[data-cy=email-label]').contains('Email');
     // Check if message label exists
-    cy.get('[data-cy=mailing-message]').contains('Message *');
+    cy.get('[data-cy=message-label]').contains('Message *');
+    // Ensure send button is disabled
+    cy.get('[data-cy=send-button]').should('be.disabled');
+    // Fill in valid message
+    cy.get('[data-cy=message-field]').type('message goes here');
+    // Ensure send button is enabled,
+    // because the message is the only required field
+    cy.get('[data-cy=send-button]').should('not.be.disabled');
   });
 });

--- a/frontend/cypress/integration/components/mailingForm.spec.js
+++ b/frontend/cypress/integration/components/mailingForm.spec.js
@@ -1,0 +1,34 @@
+describe('Mailing forms', () => {
+  it('checks labels and validation of a general form', () => {
+    // Visit engage page
+    cy.visit('/#/engage');
+    // Check if name label exists
+    cy.get('[data-cy=mailing-name]').contains('Name *');
+    // Check if email label exists
+    cy.get('[data-cy=mailing-email]').contains('Email *');
+    // Check if message label exists
+    cy.get('[data-cy=mailing-message]').contains('Message *');
+  });
+
+  it('checks labels and validation of a sponsorship form', () => {
+    // Visit sponsors page
+    cy.visit('/#/sponsors');
+    // Check if name label exists
+    cy.get('[data-cy=mailing-name]').contains('Company Name *');
+    // Check if email label exists
+    cy.get('[data-cy=mailing-email]').contains('Email *');
+    // Check if message label exists
+    cy.get('[data-cy=mailing-message]').contains('Message *');
+  });
+
+  it('checks labels and validation of a feedback form', () => {
+    // Visit engage page
+    cy.visit('/#/engage');
+    // Check if name label exists
+    cy.get('[data-cy=mailing-name]').contains('Name');
+    // Check if email label exists
+    cy.get('[data-cy=mailing-email]').contains('Email');
+    // Check if message label exists
+    cy.get('[data-cy=mailing-message]').contains('Message *');
+  });
+});

--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -12,19 +12,19 @@
     <v-col class="form-box">
       <v-form ref="form" v-model="valid">
         <!-- Name -->
-        <label class="text-body-1 input-label">{{ isType('sponsorship') ? "Company Name" : "Name" }}
+        <label class="text-body-1 input-label" data-cy="mailing-name">{{ isType('sponsorship') ? "Company Name" : "Name" }}
           <span v-if="!isType('feedback')" class="required">*</span>
         </label>
         <v-text-field class="input" placeholder="John Smith" v-model="name"
           :rules="[ !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Email -->
-        <label class="text-body-1 input-label"> Email
+        <label class="text-body-1 input-label" data-cy="mailing-email"> Email
           <span v-if="!isType('feedback')" class="required">*</span>
         </label>
         <v-text-field class="input" placeholder="john.smith@email.com" v-model="email"
           :rules="[ rules.email, !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Message -->
-        <label class="text-body-1 input-label"> Message
+        <label class="text-body-1 input-label" data-cy="mailing-message"> Message
           <span class="required">*</span>
         </label>
         <v-textarea class="input" placeholder="Message" v-model="body"

--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -12,25 +12,26 @@
     <v-col class="form-box">
       <v-form ref="form" v-model="valid">
         <!-- Name -->
-        <label class="text-body-1 input-label" data-cy="name-label">{{ isType('sponsorship') ? "Company Name" : "Name" }}
+        <label class="text-body-1 input-label" :data-cy="`${this.type}-name-label`">
+          {{ isType('sponsorship') ? "Company Name" : "Name" }}
           <span v-if="!isType('feedback')" class="required">*</span>
         </label>
-        <v-text-field class="input" placeholder="John Smith" v-model="name" data-cy="name-field"
+        <v-text-field class="input" placeholder="John Smith" v-model="name" :data-cy="`${this.type}-name-field`"
           :rules="[ !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Email -->
-        <label class="text-body-1 input-label" data-cy="email-label"> Email
+        <label class="text-body-1 input-label" :data-cy="`${this.type}-email-label`"> Email
           <span v-if="!isType('feedback')" class="required">*</span>
         </label>
-        <v-text-field class="input" placeholder="john.smith@email.com" v-model="email" data-cy="email-field"
+        <v-text-field class="input" placeholder="john.smith@email.com" v-model="email" :data-cy="`${this.type}-email-field`"
           :rules="[ rules.email, !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Message -->
-        <label class="text-body-1 input-label" data-cy="message-label"> Message
+        <label class="text-body-1 input-label" :data-cy="`${this.type}-message-label`"> Message
           <span class="required">*</span>
         </label>
-        <v-textarea class="input" placeholder="Message" v-model="body" data-cy="message-field"
+        <v-textarea class="input" placeholder="Message" v-model="body" :data-cy="`${this.type}-message-field`"
           :rules="[ rules.required ]"></v-textarea>
         <!-- Send button -->
-        <v-btn text style="margin-left:60%" :disabled="!valid" @click="send" data-cy="send-button">Send</v-btn>
+        <v-btn text style="margin-left:60%" :disabled="!valid" @click="send" :data-cy="`${this.type}-send-button`">Send</v-btn>
       </v-form>
     </v-col>
   </v-row>

--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -12,25 +12,25 @@
     <v-col class="form-box">
       <v-form ref="form" v-model="valid">
         <!-- Name -->
-        <label class="text-body-1 input-label" data-cy="mailing-name">{{ isType('sponsorship') ? "Company Name" : "Name" }}
+        <label class="text-body-1 input-label" data-cy="name-label">{{ isType('sponsorship') ? "Company Name" : "Name" }}
           <span v-if="!isType('feedback')" class="required">*</span>
         </label>
-        <v-text-field class="input" placeholder="John Smith" v-model="name"
+        <v-text-field class="input" placeholder="John Smith" v-model="name" data-cy="name-field"
           :rules="[ !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Email -->
-        <label class="text-body-1 input-label" data-cy="mailing-email"> Email
+        <label class="text-body-1 input-label" data-cy="email-label"> Email
           <span v-if="!isType('feedback')" class="required">*</span>
         </label>
-        <v-text-field class="input" placeholder="john.smith@email.com" v-model="email"
+        <v-text-field class="input" placeholder="john.smith@email.com" v-model="email" data-cy="email-field"
           :rules="[ rules.email, !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Message -->
-        <label class="text-body-1 input-label" data-cy="mailing-message"> Message
+        <label class="text-body-1 input-label" data-cy="message-label"> Message
           <span class="required">*</span>
         </label>
-        <v-textarea class="input" placeholder="Message" v-model="body"
+        <v-textarea class="input" placeholder="Message" v-model="body" data-cy="message-field"
           :rules="[ rules.required ]"></v-textarea>
         <!-- Send button -->
-        <v-btn text style="margin-left:60%" :disabled="!valid" @click="send">Send</v-btn>
+        <v-btn text style="margin-left:60%" :disabled="!valid" @click="send" data-cy="send-button">Send</v-btn>
       </v-form>
     </v-col>
   </v-row>

--- a/frontend/src/views/Engage.vue
+++ b/frontend/src/views/Engage.vue
@@ -80,7 +80,7 @@
       <v-tabs-slider></v-tabs-slider>
 
       <!-- Enquiry tab -->
-      <v-tab>Enquiry</v-tab>
+      <v-tab data-cy="general-form-tab">Enquiry</v-tab>
       <v-tab-item>
         <v-card flat tile>
           <MailingForm type="general"></MailingForm>
@@ -88,7 +88,7 @@
       </v-tab-item>
 
       <!-- Feedback tab -->
-      <v-tab>Feedback</v-tab>
+      <v-tab data-cy="feedback-form-tab">Feedback</v-tab>
       <v-tab-item>
         <v-card flat tile>
           <MailingForm type="feedback"></MailingForm>


### PR DESCRIPTION
# Change
- Created testing files for the mailing forms
- Added the necessary `data-cy` attributes to various tags in `.vue` files, to enable their interaction with Cypress.

## Change reason
Part of our current milestone to retroactively create testing for all Vue components.

## Comments
I'm checking the existence of 3 labels/text-field pairs; and I'm using the enabling/disabling of the send button to test input validation.
