### PR TITLE
CW-202 Update Engage forms

### DIFF
--- a/frontend/cypress/integration/components/mailingForm.spec.js
+++ b/frontend/cypress/integration/components/mailingForm.spec.js
@@ -6,11 +6,11 @@ describe('Mailing forms', () => {
     cy.get('[data-cy=mailing-form]');
     // By referencing general-tab items we are ensuring that it is selected by default
     // Check if name label exists and is required
-    cy.get('[data-cy=general-name-label]').contains('Name *');
+    cy.get('[data-cy=general-name-label]').contains('Name').should('have.class', 'required');
     // Check if email label exists and is required
-    cy.get('[data-cy=general-email-label]').contains('Email *');
+    cy.get('[data-cy=general-email-label]').contains('Email').should('have.class', 'required');
     // Check if message label exists and is required
-    cy.get('[data-cy=general-message-label]').contains('Message *');
+    cy.get('[data-cy=general-message-label]').contains('Message').should('have.class', 'required');
     // Ensure send button is disabled
     cy.get('[data-cy=general-send-button]').should('be.disabled');
     // Fill in valid name
@@ -34,18 +34,18 @@ describe('Mailing forms', () => {
     // Ensure the mailing form exists in the Sponsors page
     cy.get('[data-cy=mailing-form]');
     // Check if name label changed to the sponsorship form version
-    cy.get('[data-cy=sponsorship-name-label]').contains('Company Name *');
+    cy.get('[data-cy=sponsorship-name-label]').contains('Company Name').should('have.class', 'required');
   });
 
   it('checks labels and validation of a feedback form', () => {
     // Visit engage page
     cy.visit('/#/engage');
     // Select feedback form tab
-    cy.get('[data-cy=feedback-form-tab]').click();
+    cy.get('[data-cy=feedback-form-selector]').click();
     // Check if name label is not required (marked with *)
-    cy.get('[data-cy=feedback-name-label]').should('not.contain', '*');
+    cy.get('[data-cy=feedback-name-label]').should('not.have.class', 'required');
     /// Check if email label is not required (marked with *)
-    cy.get('[data-cy=feedback-email-label]').should('not.contain', '*');
+    cy.get('[data-cy=feedback-email-label]').should('not.have.class', 'required');
     // Ensure send button is disabled
     cy.get('[data-cy=feedback-send-button]').should('be.disabled');
     // Fill in valid message

--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -14,19 +14,16 @@
         <!-- Name -->
         <label :class="getLabelClass(!isType('feedback'))" :data-cy="`${this.type}-name-label`">
           {{ isType('sponsorship') ? "Company Name" : "Name" }}
-          <!-- <span v-if="!isType('feedback')" class="required">*</span> -->
         </label>
         <v-text-field class="input" placeholder="John Smith" v-model="name" :data-cy="`${this.type}-name-field`"
           :rules="[ !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Email -->
         <label :class="getLabelClass(!isType('feedback'))" :data-cy="`${this.type}-email-label`"> Email
-          <!-- <span v-if="!isType('feedback')" class="required">*</span> -->
         </label>
         <v-text-field class="input" placeholder="john.smith@email.com" v-model="email" :data-cy="`${this.type}-email-field`"
           :rules="[ rules.email, !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Message -->
         <label :class="getLabelClass(true)" :data-cy="`${this.type}-message-label`"> Message
-          <!-- <span class="required">*</span> -->
         </label>
         <v-textarea class="input" placeholder="Message" v-model="body" :data-cy="`${this.type}-message-field`"
           :rules="[ rules.required ]"></v-textarea>

--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -31,7 +31,7 @@
         <v-textarea class="input" placeholder="Message" v-model="body" :data-cy="`${this.type}-message-field`"
           :rules="[ rules.required ]"></v-textarea>
         <!-- Send button -->
-        <v-btn text style="margin-left:60%" :disabled="!valid" @click="send" :data-cy="`${this.type}-send-button`">Send</v-btn>
+        <v-btn text style="margin-left:60%" :disabled="!valid" @click="send" :data-cy="`${this.type}-send-button`">Send ></v-btn>
       </v-form>
     </v-col>
   </v-row>

--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -12,21 +12,21 @@
     <v-col class="form-box" data-cy="mailing-form">
       <v-form ref="form" v-model="valid">
         <!-- Name -->
-        <label class="text-body-1 input-label" :data-cy="`${this.type}-name-label`">
+        <label :class="getLabelClass(!isType('feedback'))" :data-cy="`${this.type}-name-label`">
           {{ isType('sponsorship') ? "Company Name" : "Name" }}
-          <span v-if="!isType('feedback')" class="required">*</span>
+          <!-- <span v-if="!isType('feedback')" class="required">*</span> -->
         </label>
         <v-text-field class="input" placeholder="John Smith" v-model="name" :data-cy="`${this.type}-name-field`"
           :rules="[ !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Email -->
-        <label class="text-body-1 input-label" :data-cy="`${this.type}-email-label`"> Email
-          <span v-if="!isType('feedback')" class="required">*</span>
+        <label :class="getLabelClass(!isType('feedback'))" :data-cy="`${this.type}-email-label`"> Email
+          <!-- <span v-if="!isType('feedback')" class="required">*</span> -->
         </label>
         <v-text-field class="input" placeholder="john.smith@email.com" v-model="email" :data-cy="`${this.type}-email-field`"
           :rules="[ rules.email, !isType('feedback') ? rules.required : true ]"></v-text-field>
         <!-- Message -->
-        <label class="text-body-1 input-label" :data-cy="`${this.type}-message-label`"> Message
-          <span class="required">*</span>
+        <label :class="getLabelClass(true)" :data-cy="`${this.type}-message-label`"> Message
+          <!-- <span class="required">*</span> -->
         </label>
         <v-textarea class="input" placeholder="Message" v-model="body" :data-cy="`${this.type}-message-field`"
           :rules="[ rules.required ]"></v-textarea>
@@ -59,6 +59,11 @@ export default {
   methods: {
     isType(name) {
       return this.type === name;
+    },
+    getLabelClass(isRequired) {
+      const lc = 'text-body-1 input-label';
+      if (isRequired) return lc.concat(' required');
+      return lc;
     },
     send() {
       APIClient.mailingAPI(MAILING_URL[this.type], this.name, this.email, this.body)
@@ -97,8 +102,8 @@ export default {
   float:left;
 }
 
-.required
-{
+.required:after {
+  content:" *";
   color: red;
-}
+  }
 </style>

--- a/frontend/src/views/Engage.vue
+++ b/frontend/src/views/Engage.vue
@@ -72,30 +72,24 @@
     </v-container>
 
     <!-- Forms -->
-    <v-tabs
-      class="elevation-2"
-      vertical
-      dark
-    >
-      <v-tabs-slider></v-tabs-slider>
+    <v-container ref="content-start" style="padding: 20px 30px 10px 30px">
+      <h2>Still have some questions?</h2>
+      <br>
 
-      <!-- Enquiry tab -->
-      <v-tab data-cy="general-form-tab">Enquiry</v-tab>
-      <v-tab-item>
-        <v-card flat tile>
-          <MailingForm type="general"></MailingForm>
-        </v-card>
-      </v-tab-item>
+      <v-btn-toggle v-model="activeForm">
+        <v-btn value="feedback">
+          Feedback
+        </v-btn>
+        <v-btn value="general">
+          Enquiry
+        </v-btn>
+      </v-btn-toggle>
 
-      <!-- Feedback tab -->
-      <v-tab data-cy="feedback-form-tab">Feedback</v-tab>
-      <v-tab-item>
-        <v-card flat tile>
-          <MailingForm type="feedback"></MailingForm>
-        </v-card>
-      </v-tab-item>
+      <v-card flat tile>
+        <MailingForm :type="this.activeForm"></MailingForm>
+      </v-card>
 
-    </v-tabs>
+    </v-container>
   </v-app>
 </template>
 
@@ -109,6 +103,7 @@ import APIClient from '../utils/APIClient';
 export default {
   name: 'Engage',
   data: () => ({
+    activeForm: 'feedback',
     socialLinks: [],
     faqLinks: []
   }),

--- a/frontend/src/views/Engage.vue
+++ b/frontend/src/views/Engage.vue
@@ -77,11 +77,11 @@
       <br>
 
       <v-btn-toggle v-model="activeForm">
-        <v-btn value="feedback">
-          Feedback
-        </v-btn>
-        <v-btn value="general">
+        <v-btn value="general" data-cy="general-form-selector">
           Enquiry
+        </v-btn>
+        <v-btn value="feedback" data-cy="feedback-form-selector">
+          Feedback
         </v-btn>
       </v-btn-toggle>
 
@@ -103,7 +103,7 @@ import APIClient from '../utils/APIClient';
 export default {
   name: 'Engage',
   data: () => ({
-    activeForm: 'feedback',
+    activeForm: 'general',
     socialLinks: [],
     faqLinks: []
   }),


### PR DESCRIPTION
# Change

- Changed the way the user switches between the _Enquiry_ and the _Feedback_ form in the Engage page.
- Added '>' to the send button.
- The *required* asterisk is now added through `:after` CSS rather than as a `<span>`, as the span was changing the font (noticeable when switching).
- Updated Cypress tests in accordance with the new layout.

## Change reason

All these changes were made to get closer to the envisioned layout in the wireframe.

## Comments

I didn't create a transition when switching forms because, as opposed to the previous layout, there is only **1 form** that changes dynamically when the form is changed. This means that form does not reset when it's switched. Lastly, the validation also changes dynamically.

I haven't used the Typography because the rest of the Engage doesn't have it. It would look weird if the Form is the only element in the page that uses it.