### PR TITLE
Extend JWT

### DIFF
--- a/backend/server/constants.go
+++ b/backend/server/constants.go
@@ -16,7 +16,7 @@ const FAQ_URL = "api/v1/faq"
 const RESOURCES_URL = "api/v1/resources"
 
 // JWT used for testing
-const AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxNTk4Mzg5MDg2LCJ6SUQiOiJ6NTEyMzQ1NiJ9.a8869YcfgBZCQcWUFuomF4Fqx9nJzT-rWpP2yRVsBWg"
+const AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxNjA2Mjc5MDg2LCJ6SUQiOiJ6NTEyMzQ1NiJ9.HElUm-Qmj9asFcemvD-8Na4dIXNEZpft3BzANxUS6ZU"
 
 var JWT_SECRET = []byte("temp_secret_until_proper_secrets_are_implemented")
 


### PR DESCRIPTION
# Change

Added 3 more months to the JWT used for testing. The new expiry timestamp is 2020-11-25 at 3:38pm (AEST).

## Change reason

The JWT expired today.

## Comments

The JWT payload has an _expiry_ field that holds an epoch timestamp. 