### PR TITLE
Ignore any video output from Cypress runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ backend/main
 
 # cypress output
 frontend/cypress/videos/
+frontend/cypress/screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ backend/main
 # vscode configurations
 **/.vscode/
 .vs
+
+# cypress output
+frontend/cypress/videos/

--- a/frontend/cypress/integration/components/communityLinks.spec.js
+++ b/frontend/cypress/integration/components/communityLinks.spec.js
@@ -1,0 +1,43 @@
+describe('Community Links Landing Page', () => {
+    beforeEach(() => {
+      cy.visit('/');
+    });
+  
+    it('finds whether the text and images are displayed', () => {
+      // Making sure that the community links are included in the landing page
+      cy.get('[data-cy=communityLinks]');
+      // making sure that the join us text is there
+      cy.get('[data-cy=communityLinks-title]');
+      // making sure that the body text is there
+      cy.get('[data-cy=communityLinks-bodyText]');
+      // making sure that the body text is there
+      cy.get('[data-cy=communityLinks-joinCommunityText]');
+      // making sure that the body text is there
+      cy.get('[data-cy=communityLinks-images]');
+
+      // making sure that each image is being displayed, and is visible after hovering
+      // TODO: figure out how to test the zoom feature, and also add sizing into it aswell
+      cy.get('[data-cy=communityLinks-facebookImage].zoom')
+        .trigger('mouseover')
+      cy.get('[data-cy=communityLinks-slackImage].zoom')
+        .trigger('mouseover')
+      cy.get('[data-cy=communityLinks-discordImage].zoom')
+        .trigger('mouseover')
+    });
+
+    /*
+    it('tests scrolling to the join us section from the top of the landing page', () => {
+      // finding the join us button and clicking it
+
+      // cypress is giving a 'the chainer inViewPort cannot be found', 
+      // might try making it a command not an assert to see if that fixes it
+      // ref: https://github.com/cypress-io/cypress/issues/877
+      cy.get('[data-cy=communityLinks]').should('not.be.inViewPort');
+      cy.get('[data-cy=joinus-button]').click();
+      // it should scroll to the join us section
+      cy.get('[data-cy=communityLinks]').should('not.be.inViewPort');
+      
+    });
+    */
+  });
+  

--- a/frontend/cypress/support/assertions.js
+++ b/frontend/cypress/support/assertions.js
@@ -1,0 +1,20 @@
+const isInViewport = (_chai, utils) => {
+    function assertIsInViewport(options) {
+  
+      const subject = this._obj;
+  
+      const bottom = Cypress.$(cy.state('window')).height();
+      const rect = subject[0].getBoundingClientRect();
+  
+      this.assert(
+        rect.top < bottom && rect.bottom < bottom,
+        "expected #{this} to be in viewport",
+        "expected #{this} to not be in viewport",
+        this._obj
+      )
+    }
+  
+    _chai.Assertion.addMethod('inViewport', assertIsInViewport)
+  };
+  
+  chai.use(isInViewport);

--- a/frontend/cypress/support/index.js
+++ b/frontend/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import './assertions'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/frontend/src/components/CommunityLink.vue
+++ b/frontend/src/components/CommunityLink.vue
@@ -1,25 +1,25 @@
 <template>
 <!-- Join Us Section -->
-    <v-container id="join" ref="joinus">
-      <h1>
+    <v-container id="join" ref="joinus" data-cy="communityLinks">
+      <h1 data-cy="communityLinks-title">
         Join Us
       </h1>
-      <p>
+      <p data-cy="communityLinks-bodyText">
         Find our stall at O-week, or just turn up an event and get to know us!
       </p>
-      <h2>
+      <h2 data-cy="communityLinks-joinCommunityText">
         Join our community online
       </h2>
-      <div id="joinImg" >
+      <div id="joinImg" data-cy="communityLinks-images">
         <a href="https://www.facebook.com/groups/csesoc">
-          <img src="@/assets/facebook_logo.png" class="zoom">
+          <img src="@/assets/facebook_logo.png" class="zoom" data-cy="communityLinks-facebookImage">
         </a>
         <a href="https://csesoc-community.slack.com/">
-          <img src="@/assets/slack_logo.png" class="zoom">
+          <img src="@/assets/slack_logo.png" class="zoom" data-cy="communityLinks-slackImage">
         </a>
         <!-- need to add in the csesoc discord link-->
         <a href="https://www.facebook.com/groups/csesoc">
-          <img src="@/assets/discord_logo.png" class="zoom">
+          <img src="@/assets/discord_logo.png" class="zoom" data-cy="communityLinks-discordImage">
         </a>
       </div>
     </v-container>

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -30,7 +30,7 @@
       <v-container class="body stack-elem">
         <v-row no-gutters style="height: 100%;">
           <!-- Page links -->
-          <v-col cols="6">
+          <v-col xs="12" sm="6">
             <div class="page-links-container" @click.stop="hide">
               <RouterLink to="/about" class="link">
                 <h2>001 | About</h2>
@@ -47,30 +47,44 @@
             </div>
           </v-col>
           <!-- Social links -->
-          <v-col cols="6">
+          <v-col xs="12" sm="6">
             <div class="social-links-container">
               <div class="push-down">
-                <a class="link" href="https://www.facebook.com/csesoc/">
-                  <p>Facebook</p>
-                </a>
-                <a class="link" href="https://www.instagram.com/csesoc_unsw/">
-                  <p>Instagram</p>
-                </a>
-                <a class="link" href="https://forms.office.com/Pages/ResponsePage.aspx?id=pM_2PxXn20i44Qhnufn7o6ecLZTBorREjnXuTY-JfmBUMEpOMFBDTU1UWkhBWllWRTNPOVJFMUNCRi4u">
-                  <p>Discord Community</p>
-                </a>
-                <a class="link" href="https://csesoc-community.slack.com/">
-                  <p>Slack Community</p>
-                </a>
-                <a class="link" href="https://www.youtube.com/channel/UC1JHpRrf9j5IKluzXhprUJg">
-                  <p>Youtube</p>
-                </a>
-                <a class="link" href="https://www.linkedin.com/company/csesoc/">
-                  <p>LinkedIn</p>
-                </a>
-                <a class="link" href="#">
-                  <p>TikTok</p>
-                </a>
+                <div class="link">
+                  <a target="_blank" href="https://www.facebook.com/csesoc/" >
+                    Facebook
+                  </a>
+                </div>
+                <div class="link">
+                  <a target="_blank" href="https://www.instagram.com/csesoc_unsw/">
+                    Instagram
+                  </a>
+                </div>
+                <div class="link">
+                  <a target="_blank" href="https://forms.office.com/Pages/ResponsePage.aspx?id=pM_2PxXn20i44Qhnufn7o6ecLZTBorREjnXuTY-JfmBUMEpOMFBDTU1UWkhBWllWRTNPOVJFMUNCRi4u">
+                    Discord Community
+                  </a>
+                </div>
+                <div class="link">
+                  <a target="_blank" href="https://csesoc-community.slack.com/">
+                    Slack Community
+                  </a>
+                </div>
+                <div class="link">
+                  <a target="_blank" href="https://www.youtube.com/channel/UC1JHpRrf9j5IKluzXhprUJg">
+                    Youtube
+                  </a>
+                </div>
+                <div class="link">
+                  <a target="_blank" href="https://www.linkedin.com/company/csesoc/">
+                    LinkedIn
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="#">
+                    TikTok
+                  </a>
+                </div>
               </div>
             </div>
           </v-col>
@@ -79,12 +93,12 @@
 
       <!-- Footer -->
       <v-container class="stack-elem">
-        <div class="footer">
+        <v-row no-gutters class="footer">
           <p style="display: inline;">
             <img height="14px" src="@/assets/moon-icon.png" style="padding-right: 5px;">
             Only Dark mode allowed here at CSESoc. Our apologies.
           </p>
-        </div>
+        </v-row>
       </v-container>
     </div>
   </div>
@@ -197,19 +211,20 @@ export default {
     width: 100%;
 
     .link {
-      text-decoration: none; /* Remove underline from links */
       text-align: right;
-      color: white;
       padding: $space-xxxs/2; /* Add some padding */
       padding-right: 0px; /* Keep it right aligned */
       cursor: pointer; /* To simulate a link */
       font-weight: normal;
       transition: all .2s ease-in-out;
-      width: 200px;
+      width: fit-content;
+      margin-left: auto;
 
-      p {
-        cursor: pointer; /* To simulate a link */
-      };
+      a {
+        @extend p; /* Copy <p> */
+        text-decoration: none; /* Remove underline from links */
+        color: white;
+      }
 
       &:hover {
         font-weight: bolder;

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -14,14 +14,14 @@
           <!-- Logo -->
           <v-col cols="2">
             <RouterLink to="/">
-              <v-img @click.stop="hide" class="logo-btn" width="140px" src="@/assets/csesoc-logo-white.svg" />
+              <v-img @click.stop="hide" class="logo-btn" width="140px" height="32px" src="@/assets/csesoc-logo-white.svg" />
             </RouterLink>
           </v-col>
           <!-- Spacer -->
           <v-spacer></v-spacer>
           <!-- Close -->
           <v-col cols="1">
-            <v-img @click.stop="hide" class="close-btn" width="32px" src="@/assets/close-icon.svg" />
+            <v-img @click.stop="hide" class="close-btn" width="32px" height="32px" src="@/assets/close-icon.svg" />
           </v-col>
         </v-row>
       </v-container>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -37,6 +37,7 @@
         target="_blank"
         v-ripple
         class="button"
+        data-cy=joinus-button
       >Join Us</a>
     </header>
 
@@ -98,8 +99,8 @@
       <Preview :items="resourceItems"/>
     </v-container>
 
-    <v-container>
-      <CommunityLinks></CommunityLinks>
+    <v-container ref="joinus">
+      <CommunityLinks ></CommunityLinks>
     </v-container>
 
     <!-- Support CSESoc -->


### PR DESCRIPTION
# Change

Add frontend/cypress/videos to .gitignore

## Change reason

After discovering that headless Cypress runs produce a video output, it was decided that said outputs should be gitignored to prevent unnecessary use of space.

