### PR TITLE
CW-214 Menu nitpicks

### DIFF
--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -51,32 +51,32 @@
             <div class="social-links-container">
               <div class="push-down">
                 <div class="link">
-                  <a href="https://www.facebook.com/csesoc/">
+                  <a target="_blank" href="https://www.facebook.com/csesoc/" >
                     Facebook
                   </a>
                 </div>
                 <div class="link">
-                  <a href="https://www.instagram.com/csesoc_unsw/">
+                  <a target="_blank" href="https://www.instagram.com/csesoc_unsw/">
                     Instagram
                   </a>
                 </div>
                 <div class="link">
-                  <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=pM_2PxXn20i44Qhnufn7o6ecLZTBorREjnXuTY-JfmBUMEpOMFBDTU1UWkhBWllWRTNPOVJFMUNCRi4u">
+                  <a target="_blank" href="https://forms.office.com/Pages/ResponsePage.aspx?id=pM_2PxXn20i44Qhnufn7o6ecLZTBorREjnXuTY-JfmBUMEpOMFBDTU1UWkhBWllWRTNPOVJFMUNCRi4u">
                     Discord Community
                   </a>
                 </div>
                 <div class="link">
-                  <a href="https://csesoc-community.slack.com/">
+                  <a target="_blank" href="https://csesoc-community.slack.com/">
                     Slack Community
                   </a>
                 </div>
                 <div class="link">
-                  <a href="https://www.youtube.com/channel/UC1JHpRrf9j5IKluzXhprUJg">
+                  <a target="_blank" href="https://www.youtube.com/channel/UC1JHpRrf9j5IKluzXhprUJg">
                     Youtube
                   </a>
                 </div>
                 <div class="link">
-                  <a href="https://www.linkedin.com/company/csesoc/">
+                  <a target="_blank" href="https://www.linkedin.com/company/csesoc/">
                     LinkedIn
                   </a>
                 </div>

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -79,12 +79,12 @@
 
       <!-- Footer -->
       <v-container class="stack-elem">
-        <div class="footer">
+        <v-row no-gutters class="footer">
           <p style="display: inline;">
             <img height="14px" src="@/assets/moon-icon.png" style="padding-right: 5px;">
             Only Dark mode allowed here at CSESoc. Our apologies.
           </p>
-        </div>
+        </v-row>
       </v-container>
     </div>
   </div>

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -30,7 +30,7 @@
       <v-container class="body stack-elem">
         <v-row no-gutters style="height: 100%;">
           <!-- Page links -->
-          <v-col cols="6">
+          <v-col xs="12" sm="6">
             <div class="page-links-container" @click.stop="hide">
               <RouterLink to="/about" class="link">
                 <h2>001 | About</h2>
@@ -47,7 +47,7 @@
             </div>
           </v-col>
           <!-- Social links -->
-          <v-col cols="6">
+          <v-col xs="12" sm="6">
             <div class="social-links-container">
               <div class="push-down">
                 <a class="link" href="https://www.facebook.com/csesoc/">

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -50,27 +50,41 @@
           <v-col xs="12" sm="6">
             <div class="social-links-container">
               <div class="push-down">
-                <a class="link" href="https://www.facebook.com/csesoc/">
-                  <p>Facebook</p>
-                </a>
-                <a class="link" href="https://www.instagram.com/csesoc_unsw/">
-                  <p>Instagram</p>
-                </a>
-                <a class="link" href="https://forms.office.com/Pages/ResponsePage.aspx?id=pM_2PxXn20i44Qhnufn7o6ecLZTBorREjnXuTY-JfmBUMEpOMFBDTU1UWkhBWllWRTNPOVJFMUNCRi4u">
-                  <p>Discord Community</p>
-                </a>
-                <a class="link" href="https://csesoc-community.slack.com/">
-                  <p>Slack Community</p>
-                </a>
-                <a class="link" href="https://www.youtube.com/channel/UC1JHpRrf9j5IKluzXhprUJg">
-                  <p>Youtube</p>
-                </a>
-                <a class="link" href="https://www.linkedin.com/company/csesoc/">
-                  <p>LinkedIn</p>
-                </a>
-                <a class="link" href="#">
-                  <p>TikTok</p>
-                </a>
+                <div class="link">
+                  <a href="https://www.facebook.com/csesoc/">
+                    Facebook
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="https://www.instagram.com/csesoc_unsw/">
+                    Instagram
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=pM_2PxXn20i44Qhnufn7o6ecLZTBorREjnXuTY-JfmBUMEpOMFBDTU1UWkhBWllWRTNPOVJFMUNCRi4u">
+                    Discord Community
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="https://csesoc-community.slack.com/">
+                    Slack Community
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="https://www.youtube.com/channel/UC1JHpRrf9j5IKluzXhprUJg">
+                    Youtube
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="https://www.linkedin.com/company/csesoc/">
+                    LinkedIn
+                  </a>
+                </div>
+                <div class="link">
+                  <a href="#">
+                    TikTok
+                  </a>
+                </div>
               </div>
             </div>
           </v-col>
@@ -197,19 +211,20 @@ export default {
     width: 100%;
 
     .link {
-      text-decoration: none; /* Remove underline from links */
       text-align: right;
-      color: white;
       padding: $space-xxxs/2; /* Add some padding */
       padding-right: 0px; /* Keep it right aligned */
       cursor: pointer; /* To simulate a link */
       font-weight: normal;
       transition: all .2s ease-in-out;
-      width: 200px;
+      width: fit-content;
+      margin-left: auto;
 
-      p {
-        cursor: pointer; /* To simulate a link */
-      };
+      a {
+        @extend p; /* Copy <p> */
+        text-decoration: none; /* Remove underline from links */
+        color: white;
+      }
 
       &:hover {
         font-weight: bolder;


### PR DESCRIPTION
# Change

- Improve the jitter when hovering over _social links_ by reducing the clicking area.
- Use breakpoints to position the _social links_ below the _page links_ when the screen size is xs (< 600px, defined by Vuetify).
- Wrap the footer with a `<v-row>` to ensure consistence throughout the page.
- Social links open on another tab.

## Change reason

To improve the user experience when using the Menu. These points were nitpicks from #106 .

## Comments

Reviewer notes: make sure to test the changes listed above to make sure they behave as expected.
