### PR TITLE
CW-212 Match CSS spacing to design guidelines

### DIFF
--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -220,7 +220,7 @@ export default {
         @extend p; /* Copy <p> */
         text-decoration: none; /* Remove underline from links */
         color: white;
-        cursor: pointer; /* To simulate a link */ 
+        cursor: pointer; /* To simulate a link */
       }
 
       &:hover {

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -220,8 +220,7 @@ export default {
         @extend p; /* Copy <p> */
         text-decoration: none; /* Remove underline from links */
         color: white;
-        cursor: pointer; /* To simulate a link */
-        line-height: 1.25em !important;
+        cursor: pointer; /* To simulate a link */ 
       }
 
       &:hover {

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -209,14 +209,12 @@ export default {
 
     .link {
       text-align: right;
-
       color: white;
       cursor: pointer; /* To simulate a link */
       font-weight: normal;
       transition: all .2s ease-in-out;
       width: fit-content;
       margin-left: auto;
-
 
       a {
         @extend p; /* Copy <p> */
@@ -225,7 +223,6 @@ export default {
         cursor: pointer; /* To simulate a link */
         line-height: 1.25em !important;
       }
-
 
       &:hover {
         font-weight: bolder;

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -204,7 +204,7 @@ export default {
 
       p {
         cursor: pointer; /* To simulate a link */
-        line-height: 20px !important;
+        line-height: 1.25em !important;
       };
 
       &:hover {

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -168,8 +168,8 @@ export default {
   .link {
     text-decoration: none; /* Remove underline from links */
     color: white;
-    padding: $space-xs/2; /* Add some padding */
-    padding-left: 0px; /* Keep it left aligned */
+    // padding: $space-xs/2; /* Add some padding */
+    // padding-left: 0px; /* Keep it left aligned */
     cursor: pointer; /* To simulate a link */
     font-weight: normal;
     transition: all .2s ease-in-out;

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -143,7 +143,6 @@ export default {
 }
 
 .footer {
-  margin-top: $space-xs;
   margin-bottom: $space-xs;
   color: white;
 }

--- a/frontend/src/components/Menu.vue
+++ b/frontend/src/components/Menu.vue
@@ -168,8 +168,6 @@ export default {
   .link {
     text-decoration: none; /* Remove underline from links */
     color: white;
-    // padding: $space-xs/2; /* Add some padding */
-    // padding-left: 0px; /* Keep it left aligned */
     cursor: pointer; /* To simulate a link */
     font-weight: normal;
     transition: all .2s ease-in-out;
@@ -200,8 +198,6 @@ export default {
       text-decoration: none; /* Remove underline from links */
       text-align: right;
       color: white;
-      padding: $space-xxxs/2; /* Add some padding */
-      padding-right: 0px; /* Keep it right aligned */
       cursor: pointer; /* To simulate a link */
       font-weight: normal;
       transition: all .2s ease-in-out;
@@ -209,6 +205,7 @@ export default {
 
       p {
         cursor: pointer; /* To simulate a link */
+        line-height: 20px !important;
       };
 
       &:hover {

--- a/frontend/src/styles/base/_spacing.scss
+++ b/frontend/src/styles/base/_spacing.scss
@@ -5,15 +5,15 @@
 // ----------------------------------------------------------------------
   // #Spacing Values
 // ----------------------------------------------------------------------
-$space-xxxs: 1.25em; // 20px on desktop
-$space-xxs: 2.5em;   // 40px on desktop
-$space-xs: 3.75em;   // 60px on desktop
-$space-sm: 5em;      // 80px on desktop
-$space-md: 6.25em;   // 100px on desktop
-$space-lg: 10em;     // 160px on desktop
-$space-xl: 12.5em;   // 200px on desktop
-$space-xxl: 15em;    // 240px on desktop
-$space-xxxl: 17.5em;  // 280px on desktop
+$space-xxxs: 20px; // 20px on desktop
+$space-xxs: 40px;   // 40px on desktop
+$space-xs: 60px;   // 60px on desktop
+$space-sm: 80px;      // 80px on desktop
+$space-md: 100px;   // 100px on desktop
+$space-lg: 160px;     // 160px on desktop
+$space-xl: 200px;   // 200px on desktop
+$space-xxl: 240px;    // 240px on desktop
+$space-xxxl: 280px;  // 280px on desktop
 
 // ----------------------------------------------------------------------
   // #Default Values

--- a/frontend/src/styles/base/_spacing.scss
+++ b/frontend/src/styles/base/_spacing.scss
@@ -5,15 +5,15 @@
 // ----------------------------------------------------------------------
   // #Spacing Values
 // ----------------------------------------------------------------------
-$space-xxxs: 20px;
-$space-xxs: 40px;
-$space-xs: 60px;
-$space-sm: 80px;
-$space-md: 100px;
-$space-lg: 160px;
-$space-xl: 200px;
-$space-xxl: 240px;
-$space-xxxl: 280px;
+$space-xxxs: 1.25em; // 20px on desktop
+$space-xxs: 2.5em;   // 40px on desktop
+$space-xs: 3.75px;   // 60px on desktop
+$space-sm: 5em;      // 80px on desktop
+$space-md: 6.25em;   // 100px on desktop
+$space-lg: 10em;     // 160px on desktop
+$space-xl: 12.5em;   // 200px on desktop
+$space-xxl: 15em;    // 240px on desktop
+$space-xxxl: 280px;  // 280px on desktop
 
 // ----------------------------------------------------------------------
   // #Default Values

--- a/frontend/src/styles/base/_spacing.scss
+++ b/frontend/src/styles/base/_spacing.scss
@@ -7,13 +7,13 @@
 // ----------------------------------------------------------------------
 $space-xxxs: 1.25em; // 20px on desktop
 $space-xxs: 2.5em;   // 40px on desktop
-$space-xs: 3.75px;   // 60px on desktop
+$space-xs: 3.75em;   // 60px on desktop
 $space-sm: 5em;      // 80px on desktop
 $space-md: 6.25em;   // 100px on desktop
 $space-lg: 10em;     // 160px on desktop
 $space-xl: 12.5em;   // 200px on desktop
 $space-xxl: 15em;    // 240px on desktop
-$space-xxxl: 280px;  // 280px on desktop
+$space-xxxl: 17.5em;  // 280px on desktop
 
 // ----------------------------------------------------------------------
   // #Default Values

--- a/frontend/src/styles/base/_spacing.scss
+++ b/frontend/src/styles/base/_spacing.scss
@@ -5,15 +5,15 @@
 // ----------------------------------------------------------------------
   // #Spacing Values
 // ----------------------------------------------------------------------
-$space-xxxs: 0.25em;
-$space-xxs: 0.375em;
-$space-xs: 0.5em;
-$space-sm: 0.75em;
-$space-md: 1.25em;
-$space-lg: 2em;
-$space-xl: 3.25em;
-$space-xxl: 5.25em;
-$space-xxxl: 8.5em;
+$space-xxxs: 20px;
+$space-xxs: 40px;
+$space-xs: 60px;
+$space-sm: 80px;
+$space-md: 100px;
+$space-lg: 160px;
+$space-xl: 200px;
+$space-xxl: 240px;
+$space-xxxl: 280px;
 
 // ----------------------------------------------------------------------
   // #Default Values


### PR DESCRIPTION
# Change

1. Adapt the new spacing system
2. Remove the extra padding in the menu links


## Change reason

To make the current menu/spacing system align with the current wireframe.

## Comments

@glebme I have fixed the spacing system and @sergiomercado19  I removed the extra spacing in the menu links (seems like we don't need to add extra padding to make it align left or right)
