### PR TITLE
CW-124 Add LDAP authentication

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/go-ldap/ldap/v3 v3.2.3
 	github.com/go-openapi/spec v0.19.8 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/go-playground/validator/v10 v10.3.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
+github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -23,6 +25,11 @@ github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NB
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.3.0/go.mod h1:7cKuhb5qV2ggCFctp2fJQ+ErvciLZrIeoOSOm6mUr7Y=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
+github.com/go-asn1-ber/asn1-ber v1.5.1 h1:pDbRAunXzIUXfx4CB2QJFv5IuPiuoW+sWvr/Us009o8=
+github.com/go-asn1-ber/asn1-ber v1.5.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-ldap/ldap v3.0.3+incompatible h1:HTeSZO8hWMS1Rgb2Ziku6b8a7qRIZZMHjsvuZyatzwk=
+github.com/go-ldap/ldap/v3 v3.2.3 h1:FBt+5w3q/vPVPb4eYMQSn+pOiz4zewPamYhlGMmc7yM=
+github.com/go-ldap/ldap/v3 v3.2.3/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjRvjKpyMg=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
@@ -204,6 +211,8 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
+golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/backend/server/login/ldap.go
+++ b/backend/server/login/ldap.go
@@ -1,0 +1,82 @@
+/*
+  LDAP
+  --
+  This part of the login module is responsible for checking whether a pair of
+  credentials is valid by binding to Active Directory over LDAP, and then using
+  the bind to search Active Directory for the name associated with the zID.
+*/
+
+package login
+
+import (
+	"log"
+	"fmt"
+	"github.com/go-ldap/ldap/v3"
+)
+
+// Define some constants we use for binding and searching.
+const (
+	ldapServer = "ad.unsw.edu.au:389"
+	suffix = "@ad.unsw.edu.au"
+	baseDN = "OU=IDM,DC=ad,DC=unsw,DC=edu,DC=au"
+)
+
+// bind opens a connection to the LDAP server and binds to it, returning
+// a pointer to the connection, the authenticated state and any errors.
+func bind(zId string, password string) (*ldap.Conn, bool, error) {
+	// Open a TCP connection to the server.
+	conn, err := ldap.Dial("tcp", ldapServer)
+  
+	if err != nil {
+		return nil, false, fmt.Errorf("Could not connect. %s", err)
+	}
+
+	err = conn.Bind(zId + suffix, password)
+  
+	if err != nil {
+	  	return conn, false, fmt.Errorf("Failed to bind. %s", err)
+	}
+	
+	return conn, true, nil
+}
+
+// login authenticates by binding with credentials, returning the authentication
+// state, and the name of the authenticated user.
+func login(zId string, password string) (bool, string, error) {
+
+	conn, auth, err := bind(zId, password)
+
+	// Ensure the connection is closed on completion.
+	defer conn.Close()
+
+	if !auth {
+		// Return any failure to bind.
+		return false, "", err
+	}
+	
+	// Otherwise, the authentication was successful, so the bind can be used
+	// to search for the user's name.
+
+	result, err := conn.Search(ldap.NewSearchRequest(
+		baseDN,
+		ldap.ScopeWholeSubtree,
+		ldap.NeverDerefAliases,
+		0, // Max time for request.
+		0, // Max size of request.
+		false, // 
+		"(cn="+zId+")", // Common name is set to the zID, and is used as search filter.
+		[]string{"displayName"}, // We only require the name of the user.
+		nil,
+	))
+	
+	if err != nil {
+		return true, "", err
+	}
+
+	// We assume zIDs are unique - that is, we only expect one entry for a 
+	// given search.
+
+	name := result.Entries[0].GetAttributeValue("displayName")
+
+	return true, name, nil
+}

--- a/backend/server/login/ldap.go
+++ b/backend/server/login/ldap.go
@@ -9,7 +9,6 @@
 package login
 
 import (
-	"log"
 	"fmt"
 	"github.com/go-ldap/ldap/v3"
 )


### PR DESCRIPTION
# Change

- Add code to bind to UNSW Active Directory to authenticate users and get their names.

## Change reason

- As the decision was made to use UNSW zID logins to authenticate users for the Content Management System, authenticating with LDAP is a necessity.

## Comments

- This code is still a work in progress - this pull request is for feedback and suggestions and most likely won't be merged for some time.
- As a login system hasn't been fully implemented yet, and isn't expected to be for at least a week, no code in ldap.go is referenced outside that file.
- This code was tested independently on my CSE account, since we haven't been able to deploy to a CSE hypervisor (Wheatley) yet.
