### PR TITLE
CW-191 Landing page events frontend tests

### DIFF
--- a/frontend/cypress/integration/components/landingPageEvents.spec.js
+++ b/frontend/cypress/integration/components/landingPageEvents.spec.js
@@ -1,0 +1,33 @@
+describe('Landing page events', () => {
+    it('checks for a slideshow of events on regular viewports, or a message otherwise', () => {
+      cy.visit('/');
+      cy.get('[data-cy=event-section]').then(($eventSection) => {
+          if ($eventSection.children('[data-cy=event-alert]').length > 0) {
+            // Ensure that the alert exists before asserting it.
+            cy.get('[data-cy=event-alert]').should('be.visible');
+        } else {
+            // Otherwise, the slider must exist, and the event list should not,
+            // as this is a desktop viewport.
+            cy.get('[data-cy=event-slider]').should('be.visible');
+            cy.get('[data-cy=event-list]').should('not.be.visible');
+        }
+    });      
+});
+
+it('checks for a list of events on mobile viewports, or a message otherwise', () => {
+    cy.visit('/');
+    cy.viewport('iphone-6');
+    cy.get('[data-cy=event-section]').then(($eventSection) => {
+        if ($eventSection.children('[data-cy=event-alert]').length > 0) {
+            // Ensure that the alert exists before asserting it.
+            cy.get('[data-cy=event-alert]').should('be.visible');
+        } else {
+            // Otherwise, the list must exist, and the slider should not,
+            // as this is a mobile viewport.
+            cy.get('[data-cy=event-slider]').should('not.be.visible');
+            cy.get('[data-cy=event-list]').should('be.visible');
+          }
+        });
+    });   
+});
+  

--- a/frontend/src/components/EventDisplay.vue
+++ b/frontend/src/components/EventDisplay.vue
@@ -10,21 +10,21 @@
 -->
 
 <template>
-  <v-container>
+  <v-container data-cy="event-section">
     <!-- Catch a lack of events, or if events haven't been updated in 60 days. -->
-    <div v-if="events.length == 0 | updated > 86400 * 1000 * 60">
+    <div data-cy="event-alert" v-if="events.length == 0 | updated > 86400 * 1000 * 60">
       Stay tuned to our Facebook page for upcoming events!
     </div>
 
     <!-- Display all events in a sliding component on desktop viewports. -->
-    <v-slide-group show-arrows dark class="hidden-sm-and-down">
+    <v-slide-group data-cy="event-slider" show-arrows dark class="hidden-sm-and-down">
       <v-slide-item v-for="event in events" :key="event.id" style="margin-right: 20px;">
         <Event :event = "event"></Event>
       </v-slide-item>
     </v-slide-group>
 
     <!-- Otherwise, list all events on mobile. -->
-    <v-row class="hidden-md-and-up" v-for="event in events.slice(0,3)" :key="event.id">
+    <v-row class="hidden-md-and-up" data-cy="event-list" v-for="event in events" :key="event.id">
         <Event :event = "event" style="margin: 0 auto; margin-bottom: 20px;"></Event>
     </v-row>
   </v-container>


### PR DESCRIPTION
# Change

- Create frontend tests for landing page events on both desktop and mobile viewports.

## Change reason

- Frontend testing is an essential part of our CI workflow, and no tests existed for events yet.

