### PR TITLE
CW-228 Removing JWT secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         env:
           MAILJET_TOKEN: ${{ secrets.MAILJET_TOKEN }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          TESTING_JWT: ${{ secrets.TESTING_JWT }}
         run: docker-compose up -d --build backend mongo
       - name: Golang Tests
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Building docker containers using docker-compose
         env:
           MAILJET_TOKEN: ${{ secrets.MAILJET_TOKEN }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: docker-compose up -d --build backend mongo
       - name: Golang Tests
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Golang Tests
         run: go test ./...
         working-directory: ./backend/server
+        env:
+          TESTING_JWT: ${{ secrets.TESTING_JWT }}
+          
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
         run: go test ./...
         working-directory: ./backend/server
         env:
-          TESTING_JWT: ${{ secrets.TESTING_JWT }}
-          
+          TESTING_JWT: ${{ secrets.TESTING_JWT }} 
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/backend/server/constants.go
+++ b/backend/server/constants.go
@@ -18,7 +18,7 @@ const FAQ_URL = "api/v1/faq"
 const RESOURCES_URL = "api/v1/resources"
 
 // JWT used for testing
-const AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxNjA2Mjc5MDg2LCJ6SUQiOiJ6NTEyMzQ1NiJ9.HElUm-Qmj9asFcemvD-8Na4dIXNEZpft3BzANxUS6ZU"
+const AUTH_TOKEN = "Bearer " + os.Getenv("TESTING_JWT")
 
 var JWT_SECRET = []byte(os.Getenv("JWT_SECRET"))
 

--- a/backend/server/constants.go
+++ b/backend/server/constants.go
@@ -6,6 +6,8 @@
 
 package utility
 
+import "os"
+
 const DEVELOPMENT bool = true
 const BASE_URL = "http://localhost:1323/"
 const SPONSOR_URL = "api/v1/sponsors"
@@ -18,7 +20,7 @@ const RESOURCES_URL = "api/v1/resources"
 // JWT used for testing
 const AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxNjA2Mjc5MDg2LCJ6SUQiOiJ6NTEyMzQ1NiJ9.HElUm-Qmj9asFcemvD-8Na4dIXNEZpft3BzANxUS6ZU"
 
-var JWT_SECRET = []byte("temp_secret_until_proper_secrets_are_implemented")
+var JWT_SECRET = []byte(os.Getenv("JWT_SECRET"))
 
 // Constants for accessing FB API
 const FB_API_PATH = "https://graph.facebook.com/v7.0"

--- a/backend/server/constants.go
+++ b/backend/server/constants.go
@@ -18,7 +18,7 @@ const FAQ_URL = "api/v1/faq"
 const RESOURCES_URL = "api/v1/resources"
 
 // JWT used for testing
-const AUTH_TOKEN = "Bearer " + os.Getenv("TESTING_JWT")
+var AUTH_TOKEN = "Bearer " + os.Getenv("TESTING_JWT")
 
 var JWT_SECRET = []byte(os.Getenv("JWT_SECRET"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
             - MAILJET_TOKEN=${MAILJET_TOKEN}
             - FB_TOKEN=${FB_TOKEN}
             - JWT_SECRET=${JWT_SECRET}
+            - TESTING_JWT=${TESTING_JWT}
     mongo:
         image: mongo:latest
         restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
         environment: 
             - MAILJET_TOKEN=${MAILJET_TOKEN}
             - FB_TOKEN=${FB_TOKEN}
+            - JWT_SECRET=${JWT_SECRET}
     mongo:
         image: mongo:latest
         restart: always


### PR DESCRIPTION
# Change

- Secrets have been removed from the source entirely.

## Change reason

- This is in preparation for deployment, where any secrets will be injected through environment variables.

## Comments

- @sergiomercado19 will need to update the instructions on updating JWTs so that the new token is stored in the TESTING_JWT GitHub secret.
- Anyone wishing to run tests locally will require both the JWT_SECRET and TESTING_JWT in their .env file. If so, they may use their own JWT key to generate a testing JWT, or a secure means of sharing .env files between developers should be decided upon.