### PR TITLE
CW-235 Disable Swagger for deployment

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -164,9 +164,11 @@ func serveAPI(e *echo.Echo) {
 	// Swagger Setup
 	////////////////
 
-	println("Serving Swagger...")
-	// SwaggerUI can be accessed from: http://localhost:1323/swagger/index.html
-	e.GET("/swagger/*", echoSwagger.WrapHandler)
+	if DEVELOPMENT {
+		println("Serving Swagger...")
+		// SwaggerUI can be accessed from: http://localhost:1323/swagger/index.html
+		e.GET("/swagger/*", echoSwagger.WrapHandler)
+	}
 
 	///////////////////////
 	// Binding API Handlers


### PR DESCRIPTION
# Change

- Swagger is only exposed when in DEVELOPMENT (represented by a constant from `constants.go`).

## Change reason

Disabling Swagger for deployment seemed like a reasonable thing to do to prevent the unnecessary exposure of the website’s backend.

## Comments

This was done as discussed during the standup.
