### PR TITLE
CW-242 Engage form switch

### DIFF
--- a/frontend/src/components/MailingForm.vue
+++ b/frontend/src/components/MailingForm.vue
@@ -50,7 +50,7 @@ export default {
     body: '',
     rules: {
       required: (value) => !!value || 'Required',
-      email: (value) => value.length === 0 || isEmail(value) || 'Invalid e-mail',
+      email: (value) => value === undefined || value.length === 0 || isEmail(value) || 'Invalid e-mail',
     },
   }),
   methods: {

--- a/frontend/src/views/Engage.vue
+++ b/frontend/src/views/Engage.vue
@@ -76,7 +76,7 @@
       <h2>Still have some questions?</h2>
       <br>
 
-      <v-btn-toggle v-model="activeForm">
+      <v-btn-toggle v-model="activeForm" mandatory>
         <v-btn value="general" data-cy="general-form-selector">
           Enquiry
         </v-btn>


### PR DESCRIPTION
# Change

- Made the Engage form toggle mandatory.
- Fixed error with email validation when the value is undefined.

## Change reason

These are two small bugs that I noticed while testing other components.

## Comments

It should not be possible to deselect all options in the form-switch button group. Sending an email, with deselected buttons causes the message to fail to send, but without giving an error.
