### PR TITLE
CW-245 Duplicate database keys

### DIFF
--- a/backend/server/faq/faq.go
+++ b/backend/server/faq/faq.go
@@ -55,8 +55,12 @@ func Setup(client *mongo.Client) {
 		log.Fatal("Could not retrive Faqs from JSON")
 	}
 
+	// Try to update; insert if document is not found
+	optUpsert := options.Update().SetUpsert(true)
 	for _, faq := range faqs {
-		if _, err := faqColl.InsertOne(context.TODO(), faq); err != nil {
+		filter := bson.M{"name": faq.Question}
+		update := bson.M{"$set": faq}
+		if _, err := faqColl.UpdateOne(context.TODO(), filter, update, optUpsert); err != nil {
 			log.Printf("Could not insert faqs " + faq.Question + " " + err.Error())
 		}
 	}

--- a/backend/server/social/social.go
+++ b/backend/server/social/social.go
@@ -58,8 +58,12 @@ func Setup(client *mongo.Client) {
 		log.Fatal("Could not retrive social links from JSON")
 	}
 
+	// Try to update; insert if document is not found
+	optUpsert := options.Update().SetUpsert(true)
 	for _, social := range socials {
-		if _, err := socialColl.InsertOne(context.TODO(), social); err != nil {
+		filter := bson.M{"name": social.Title}
+		update := bson.M{"$set": social}
+		if _, err := socialColl.UpdateOne(context.TODO(), filter, update, optUpsert); err != nil {
 			log.Printf("Could not insert social link " + social.Title + " " + err.Error())
 		}
 	}


### PR DESCRIPTION
# Change

- Employ `upsert` when initalizing Faq
- Employ `upsert` when initalizing Social

## Change reason

Using `insert` was causing the duplication of database keys.

## Comments

This error occurs due to hot-reloading. The JSON file is read and dumped on the database every time the server starts, causing duplication.

_Note_: Upsert tries to update; however, if the document is not found, it inserts it.
