### PR TITLE
make H1 smaller for when screen size is less than 450px

### DIFF
--- a/frontend/src/components/HeaderTitle.vue
+++ b/frontend/src/components/HeaderTitle.vue
@@ -10,7 +10,7 @@
 
 <template>
   <div class="header-title">
-    <h1>{{ title }}</h1>
+    <h1 v-bind:style="{padding: padding}">{{ title }}</h1>
     <h4 v-if="subtitle !== false">{{ subtitle }}</h4>
   </div>
 </template>
@@ -25,7 +25,18 @@ export default {
     },
     subtitle: {
       default: false,
+    },
+    padding: {
+      required: false,
     }
   }
 };
 </script>
+
+<style scoped>
+@media only screen and (max-width: 450px) {
+  .header-title > h1 {
+    font-size: 2.5em;
+  }
+}
+</style>

--- a/frontend/src/views/About.vue
+++ b/frontend/src/views/About.vue
@@ -17,7 +17,7 @@
     ></v-parallax>
     <!-- About -->
     <v-container ref="content-start" style="padding: 0px 30px 10px 30px">
-      <HeaderTitle title="About"></HeaderTitle>
+      <HeaderTitle title="About" padding="50px 0px 0px 0px"></HeaderTitle>
       <p><b>
         CSESoc is the principal representative body for computing students on campus. We are one of the biggest and most
         active societies at UNSW, catering to over 3500 CSE students spanning across degrees in


### PR DESCRIPTION
# Change

Changed H1 header title component to include a media query which decreases the size of all H1 elements when in mobile view i.e. when width less than 450px, to decrease overflow
