### PR TITLE
Wm2 9 component top navbar

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,19 +1,7 @@
 <template>
   <v-app id="main-app">
     <!-- Navigation bar/app bar goes here -->
-    <v-app-bar app color="transparent" class="blend" elevation="0" width="100vw">
-      <!-- Logo -->
-      <RouterLink to="/" v-on:click.native="showMenu = false">
-        <v-container class="fill-height" style="max-height: 64px; max-width:100px">
-          <v-img src="@/assets/csesocwhiteblue.png" />
-        </v-container>
-      </RouterLink>
-
-      <div class="flex-grow-1"></div>
-
-      <!-- Menu button -->
-      <v-app-bar-nav-icon color="white" class="ma-2" data-cy="menu-toggle" @click.stop="showMenu = !showMenu" />
-    </v-app-bar>
+    <Navbar />
     <v-main class="pa-0">
       <Menu v-if="showMenu" @shown="onMenuCollapse" />
       <RouterView style="overflow-x: hidden" />
@@ -25,6 +13,7 @@
 <script>
 import Footer from '@/components/Footer';
 import Menu from '@/components/Menu';
+import Navbar from '@/components/Navbar';
 
 export default {
   name: 'App',
@@ -34,6 +23,7 @@ export default {
   components: {
     Footer,
     Menu,
+    Navbar,
   },
   methods: {
     onMenuCollapse(val) {
@@ -62,5 +52,4 @@ html, body {
 .blend{
   mix-blend-mode: exclusion;
 }
-
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,5 @@
 <template>
   <v-app id="main-app">
-    <!-- Navigation bar/app bar goes here -->
     <Navbar />
     <v-main class="pa-0">
       <Menu v-if="showMenu" @shown="onMenuCollapse" />

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -83,9 +83,6 @@
 <script type="text/javascript">
 export default {
   name: 'Navbar',
-  data: () => ({
-    showMenu: false
-  }),
   methods: {
     goto(refName) {
       const element = document.getElementById(refName);

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -1,0 +1,96 @@
+<!--
+  Navbar
+  --
+  This component is static on the top of the page and displays links to different parts
+    the screen
+-->
+
+<template>
+  <v-app-bar app color="rgba(0,0,51,0.7)" elevation="0" width="100vw">
+    <!-- Large screen display -->
+    <v-container class="hidden-sm-and-down">
+      <v-row class="d-flex justify-center">
+        <v-col class="d-flex align-center justify-start">
+          <a @click="goto('showcase')" style="text-decoration: none;">
+            <v-img contain max-height="60px" max-width="100px" src="@/assets/csesocwhiteblue.png" />
+          </a>
+        </v-col>
+        <v-col class="d-flex align-center justify-center">
+          <a @click="goto('mission')" style="text-decoration: none;">
+            <v-btn text color="white">ABOUT US</v-btn>
+          </a>
+        </v-col>
+        <v-col class="d-flex align-center justify-center">
+          <a @click="goto('student-resources')" style="text-decoration: none;">
+            <v-btn text color="white">GET IN TOUCH</v-btn>
+          </a>
+        </v-col>
+        <v-col class="d-flex align-center justify-center">
+          <a @click="goto('student-resources')" style="text-decoration: none;">
+              <v-btn text color="white">RESOURCES</v-btn>
+          </a>
+        </v-col>
+        <v-col class="d-flex align-center justify-center">
+            <v-btn text to="/sponsorship" color="white">SPONSORSHIP</v-btn>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <!-- Smaller screen container -->
+    <v-container class="hidden-md-and-up">
+      <v-row class="d-flex justify-space-between">
+        <v-col class="d-flex align-center">
+          <RouterLink  to="/" style="text-decoration: none;" v-on:click.native="showMenu = false">
+            <v-img contain max-height="40px" max-width="100px" src="@/assets/csesocwhiteblue.png" />
+          </RouterLink>
+        </v-col>
+        <v-col class="d-flex justify-end">
+          <v-menu bottom left>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn dark icon v-bind="attrs" v-on="on">
+                <v-icon>mdi-menu</v-icon>
+              </v-btn>
+            </template>
+            <v-list>
+              <v-list-item>
+                <a @click="goto('mission')" style="text-decoration: none; color: black;">
+                  About us
+                </a>
+              </v-list-item>
+              <v-list-item>
+                <a @click="goto('community')" style="text-decoration: none; color: black;">
+                  Get in touch
+                </a>
+              </v-list-item>
+              <v-list-item>
+                <a @click="goto('student-resources')" style="text-decoration: none; color: black;">
+                  Resources
+                </a>
+              </v-list-item>
+              <v-list-item>
+                <RouterLink style="text-decoration: none; color: black;" to="/sponsorship">
+                  Sponsorship
+                </RouterLink>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-app-bar>
+</template>
+
+<script type="text/javascript">
+export default {
+  name: 'Navbar',
+  data: () => ({
+    showMenu: false
+  }),
+  methods: {
+    goto(refName) {
+      const element = document.getElementById(refName);
+      element.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    }
+  }
+};
+</script>


### PR DESCRIPTION
# Change

Add a Navbar component reflecting the mockup.

## Change reason

Needed for cleaner navigation around site.

Links collapse into a drop down when window is resized to sm breakpoint and below.

## Comments

Need to adjust links to go to actual components on home page, right now only really two of them work. About us links to mission and csesoc logo links to top of page, will adjust once new sections are added.

Scrollintoview does not allow for offset, may adjust in future if needed.
