### PR TITLE
Fb embed

### DIFF
--- a/frontend/src/views/Home/EventDisplay.vue
+++ b/frontend/src/views/Home/EventDisplay.vue
@@ -11,33 +11,46 @@
 
 <template>
   <div id="event-display" class="content">
-    <v-container data-cy="event-section">
-      <HeaderTitle
-        title="UPCOMING EVENTS"
-        subtitle="We run a wide-variety of events for fun, learning new skills and careers."
-      />
-      <!-- Catch a lack of events, or if events haven't been updated in 60 days. -->
-      <div data-cy="event-alert" v-if="events.length == 0 | updated > 86400 * 1000 * 60">
-        For full listings, check out the CSESoc Discord or our Facebook page!
-      </div>
-
+    <v-container data-cy="event-section" class="Container">
+      <v-container>
+        <HeaderTitle
+          title="UPCOMING EVENTS"
+          subtitle="We run a wide-variety of events for fun, learning new skills and careers."
+        />
+        <!-- Catch a lack of events, or if events haven't been updated in 60 days. -->
+        <div data-cy="event-alert" v-if="events.length == 0 | updated > 86400 * 1000 * 60">
+          For full listings, check out the CSESoc Discord or our Facebook page!
+        </div>
+      </v-container>
+      <!-- Facebook embedded event page viewer -->
+      <v-container class="Embed">
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fcsesoc&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId"
+          width="340"
+          height="500"
+          style="border:none;overflow:hidden"
+          scrolling="no"
+          frameborder="0"
+          allowfullscreen="true"
+          allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+        />
+      </v-container>
       <!-- Display all events in a sliding component on desktop viewports. -->
-      <v-slide-group data-cy="event-slider" show-arrows dark class="hidden-sm-and-down">
+      <!-- <v-slide-group data-cy="event-slider" show-arrows dark class="hidden-sm-and-down">
         <v-slide-item v-for="event in events" :key="event.id" style="margin-right: 20px;">
           <Event :event = "event"></Event>
         </v-slide-item>
-      </v-slide-group>
+      </v-slide-group> -->
 
       <!-- Otherwise, list all events on mobile. -->
-      <v-row data-cy="event-list" class="hidden-md-and-up" v-for="event in events.slice(0,3)" :key="event.id">
+      <!-- <v-row data-cy="event-list" class="hidden-md-and-up" v-for="event in events.slice(0,3)" :key="event.id">
           <Event :event = "event" style="margin: 0 auto; margin-bottom: 20px;"></Event>
-      </v-row>
+      </v-row> -->
     </v-container>
   </div>
 </template>
 
 <script type="text/javascript">
-import Event from '@/components/Event';
+// import Event from '@/components/Event';
 import HeaderTitle from '@/components/HeaderTitle';
 
 export default {
@@ -46,8 +59,29 @@ export default {
   // items have title, image url (src), and link
   props: ['events', 'updated'],
   components: {
-    Event,
+    // Event,
     HeaderTitle,
   }
 };
 </script>
+
+<style scoped>
+  .Container {
+    display: flex;
+    flex-direction: row;
+  }
+  .Embed {
+    display: flex;
+    justify-content: flex-end;
+    margin-right: 50px;
+  }
+  @media screen and (max-width: 700px) {
+    .Container {
+      flex-direction: column;
+    }
+    .Embed {
+      justify-content: center;
+      margin-top: 50px;
+    }
+  }
+</style>

--- a/frontend/src/views/Home/EventDisplay.vue
+++ b/frontend/src/views/Home/EventDisplay.vue
@@ -11,33 +11,46 @@
 
 <template>
   <div id="event-display" class="content">
-    <v-container data-cy="event-section">
-      <HeaderTitle
-        title="UPCOMING EVENTS"
-        subtitle="We run a wide-variety of events for fun, learning new skills and careers."
-      />
-      <!-- Catch a lack of events, or if events haven't been updated in 60 days. -->
-      <div data-cy="event-alert" v-if="events.length == 0 | updated > 86400 * 1000 * 60">
-        For full listings, check out the CSESoc Discord or our Facebook page!
-      </div>
-
+    <v-container data-cy="event-section" class="Container">
+      <v-container>
+        <HeaderTitle
+          title="UPCOMING EVENTS"
+          subtitle="We run a wide-variety of events for fun, learning new skills and careers."
+        />
+        <!-- Catch a lack of events, or if events haven't been updated in 60 days. -->
+        <div data-cy="event-alert" v-if="events.length == 0 | updated > 86400 * 1000 * 60">
+          For full listings, check out the CSESoc Discord or our Facebook page!
+        </div>
+      </v-container>
+      <!-- Facebook embedded event page viewer -->
+      <v-container class="Embed">
+        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fcsesoc&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId"
+          width="340"
+          height="500"
+          style="border:none;overflow:hidden"
+          scrolling="no"
+          frameborder="0"
+          allowfullscreen="true"
+          allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+        />
+      </v-container>
       <!-- Display all events in a sliding component on desktop viewports. -->
-      <v-slide-group data-cy="event-slider" show-arrows dark class="hidden-sm-and-down">
+      <!-- <v-slide-group data-cy="event-slider" show-arrows dark class="hidden-sm-and-down">
         <v-slide-item v-for="event in events" :key="event.id" style="margin-right: 20px;">
           <Event :event = "event"></Event>
         </v-slide-item>
-      </v-slide-group>
+      </v-slide-group> -->
 
       <!-- Otherwise, list all events on mobile. -->
-      <v-row data-cy="event-list" class="hidden-md-and-up" v-for="event in events.slice(0,3)" :key="event.id">
+      <!-- <v-row data-cy="event-list" class="hidden-md-and-up" v-for="event in events.slice(0,3)" :key="event.id">
           <Event :event = "event" style="margin: 0 auto; margin-bottom: 20px;"></Event>
-      </v-row>
+      </v-row> -->
     </v-container>
   </div>
 </template>
 
 <script type="text/javascript">
-import Event from '@/components/Event';
+// import Event from '@/components/Event';
 import HeaderTitle from '@/components/HeaderTitle';
 
 export default {
@@ -46,8 +59,27 @@ export default {
   // items have title, image url (src), and link
   props: ['events', 'updated'],
   components: {
-    Event,
+    // Event,
     HeaderTitle,
   }
 };
 </script>
+
+<style scoped>
+  .Container {
+    display: flex;
+    flex-direction: row;
+  }
+  .Embed {
+    display: flex;
+    justify-content: center;
+  }
+  @media screen and (max-width: 700px) {
+    .Container {
+      flex-direction: column;
+    }
+    .Embed {
+      margin-top: 50px;
+    }
+  }
+</style>


### PR DESCRIPTION
# Change

implemented facebook csesoc page embed, replacing current 'events' tab. 
- mobile compatible
see photos

![image](https://user-images.githubusercontent.com/47090372/137297272-028e87a1-821c-47b0-a506-95855cd065af.png)

![image](https://user-images.githubusercontent.com/47090372/137297340-3df1d8b7-1bda-46bc-bff7-c9fdfa6626f3.png)
